### PR TITLE
Move prerequisites to start of chapter

### DIFF
--- a/chapters/reproducibility.md
+++ b/chapters/reproducibility.md
@@ -1,23 +1,23 @@
 # What is reproducible science?
 
+## Prerequisites / recommended skill level
+No previous knowledge needed.
+
 ## Summary
 There are several definitions of reproducibility in use.
 This chapter will lay out why reproducibility is important for science and scientists, provide an overview of the most common definitions and define reproducibility for the context of this handbook.
 
 ## How this will help you/ why this is useful
-This chapter sets out the definition of reproducibility that the Turing Way project team used when writing this handbook. 
-It will be useful to avoid misunderstandings when reading the rest of the handbook. 
+This chapter sets out the definition of reproducibility that the Turing Way project team used when writing this handbook.
+It will be useful to avoid misunderstandings when reading the rest of the handbook.
 
-## Prerequisites / recommended skill level
-No previous knowledge needed. 
-
-## Chapter content 
+## Chapter content
 
 ### Why reproducibility is important for science
 
 Major media outlets have [reported on](https://www.theguardian.com/science/2018/aug/27/attempt-to-replicate-major-social-scientific-findings-of-past-decade-fails) investigations that show that a significant percentage of scientific studies cannot be reproduced.  
 This leads to other academics and society losing trust in scientific results. (Baker, 2016).
-Working reproducibly means others can check your results - even early on in the research process. 
+Working reproducibly means others can check your results - even early on in the research process.
 Thus, the full analysis and methodology is transparent.
 Scientific results and evidence are strenghtened if they are reproduced and confirmed by several indepedent researchers.
 With all parts used in an analyses being available and/or documented, valuable time is saved reproducing published results and other researchers can easily build on these resarch results and re-use data or code for their analyses.
@@ -27,21 +27,21 @@ In addition, so called "negative results" can be published easily and avoid that
 
 Markowetz highlights five reasons to work reprodubily (Markowetz, 2015):
 - Avoiding disaster: Through working reproducibly, you can trust your own research results and will not have to retract published results or keep publications back because you cannot reproduce your results.
-- Writing papers easier: well documented analyses ensure you have easy access to the latest results, your work can easily be written up and collaborators can easily get on board as additional authors. 
+- Writing papers easier: well documented analyses ensure you have easy access to the latest results, your work can easily be written up and collaborators can easily get on board as additional authors.
 Furthermore, you can be sure that you easily comply with the highest-level journal guidelines.
 - Convincing reviewers: Making code and data available to the reviewers means their review comments will be constructive as they are able to develop an in-depth understanding of your work and can even try changes to your analysis themselves and see the impact.
 - Facilitating continuity of work: Well documented work means your work can easily be picked up and continued - either by others in your lab or yourself if you want to build on your own work after a longer period.
-- Building your reputation: Putting in effort to make your research reproducible shows that you are a careful researcher and makes your research results more robust. 
+- Building your reputation: Putting in effort to make your research reproducible shows that you are a careful researcher and makes your research results more robust.
 
-Papers whose underlying data is available get cited more often (Piwowar, Day & Fridsma, 2007, Piwowar & Vision, 2013). 
-All research outputs that are shared can be built upon more easily by others and in some cases, others following up on your work might lead to new collaborations. 
-Other benefits of working openly are covered in our Open Science chapter. 
+Papers whose underlying data is available get cited more often (Piwowar, Day & Fridsma, 2007, Piwowar & Vision, 2013).
+All research outputs that are shared can be built upon more easily by others and in some cases, others following up on your work might lead to new collaborations.
+Other benefits of working openly are covered in our Open Science chapter.
 
 
 ### Definitions of reproducibility
 
-The most common definition of reproducibility (and replication) was first noted by Claerbout and Karrenbach in 1992 and has been used in computational science literature since then. 
-Another popular definition has been introduced in 2013 by the Association for Computing Machinery (ACM) which swapped the meaning of the terms 'reproducible' and 'replicable' compared to Claerbout and Karrenbach. 
+The most common definition of reproducibility (and replication) was first noted by Claerbout and Karrenbach in 1992 and has been used in computational science literature since then.
+Another popular definition has been introduced in 2013 by the Association for Computing Machinery (ACM) which swapped the meaning of the terms 'reproducible' and 'replicable' compared to Claerbout and Karrenbach.
 The following table contrasts both definitions following Heroux et al. (2018).
 
 | Term | Claerbout & Karrenbach | ACM |
@@ -50,24 +50,24 @@ The following table contrasts both definitions following Heroux et al. (2018).
 | Replicable |  A study that arrives at the same scientific findings as another study, collecting new data (possibly with different methods) and completing new analyses. | (Different team, same experimental setup.) The measurement can be obtained with stated precision by a different team using the same measurement procedure, the same measuring system, under the same operating conditions, in the same or a different location on multiple trials. For computational experiments, this means that an independent group can obtain the same result using the author's own artifacts. |
 
 Barba (2018) conducted a detailed literature review on the usage of reproducible/replicable covering several disciplines.
-Most papers and disciplines use the terminology as defined by Claerbout and Karrenbach, whereas mircobiology, immunology and computer science tend to follow the ACM use of reproducibility and replication. 
+Most papers and disciplines use the terminology as defined by Claerbout and Karrenbach, whereas mircobiology, immunology and computer science tend to follow the ACM use of reproducibility and replication.
 In political science and economics literature, both terms are used interchangeably.
 
-In addition to these high level definitions of reporducibility, some authors provide more deailed disctinctions. 
+In addition to these high level definitions of reporducibility, some authors provide more deailed disctinctions.
 Victoria Stodden [(2014)](http://edge.org/response-detail/25340), a prominent scholar on this topic, has for example identified the following further distinctions:
 
 - _Computational reproducibility_: when detailed information is provided about code, software, hardware and implementation details.
 
 - _Empirical reproducibility_: when detailed information is provided about non-computational empirical scientific experiments and observations. In practise this is enabled by making data freely available, as well as details of how the data was collected.
 
-- _Statistical reproducibility_: when detailed information is provided about the choice of statistical tests, model parameters, threshold values, etc. This mostly relates to pre-registration of study design to prevent p-value hacking and other manipulations. 
+- _Statistical reproducibility_: when detailed information is provided about the choice of statistical tests, model parameters, threshold values, etc. This mostly relates to pre-registration of study design to prevent p-value hacking and other manipulations.
 
 
 ### The Turing Way definition of reproducibility
 
 The Turing Way project will define reproducible research as both data and code being available to fully rerun the analysis.
 ![Kirstie's definition of reproducible research](https://github.com/pherterich/the-turing-way/blob/master/reproducibility_kirstie.png)
-However, we recognize that some research will use sensitive data that cannot be shared and this handbook will provide guides on how your research can be reproducible without all parts necessarily being open. 
+However, we recognize that some research will use sensitive data that cannot be shared and this handbook will provide guides on how your research can be reproducible without all parts necessarily being open.
 The handbook will cover:
 * Version control (using git)
 * Using GitHub/GitLab for collaboration
@@ -76,7 +76,7 @@ The handbook will cover:
 * Reproducible computing environments
 * Testing
 * Continous integration
-* Various case studies 
+* Various case studies
 * Checklists to get you started on reproducible practices
 
 ## Checklist/Exercise
@@ -86,7 +86,7 @@ The handbook will cover:
 Open Science will be a good chapter to read next.
 If you want to start learning hands-on practices, we recommend learning about version control next.
 
-## Bibliography 
+## Bibliography
 
 * Baker, M. (2016). 1,500 scientists lift the lid on reproducibility. Nature, 533(7604), 452–454. https://doi.org/10.1038/533452a
 
@@ -106,7 +106,7 @@ If you want to start learning hands-on practices, we recommend learning about ve
 
 * Whitaker, Kirstie (2018): Barriers to reproducible research (and how to overcome them). figshare. Paper. https://doi.org/10.6084/m9.figshare.7140050.v2
 
-## Additional material 
+## Additional material
 ### Videos
 
 * Markowetz, F. (2016). 5 selfish reasons to work reproducibly. Talk at scidata 2016. https://www.youtube.com/watch?v=Is15CMVPHas&feature=youtu.be

--- a/chapters/version_control.md
+++ b/chapters/version_control.md
@@ -4,7 +4,7 @@
 
 | Prerequisite | Importance | Notes |
 | -------------|:----------:|------:|
-|Some experience of working via the command line | Extremely helpful but not a necessity as it is possible to use version control through desktop and web browser based tools | Desktop/web based tools are discussed towards the end of this chapter, but the general principles and best practice discussed in the preceding sections are relevant regardless of whether the command line or a GUI is used. |
+|Experience with the command line | Helpful | It is possible to use version control through desktop and web browser based tools. These are discussed towards the end of this chapter, but the general principles and best practice discussed in the preceding sections are relevant regardless of whether the command line or a GUI is used. |
 
 Recommended skill level: beginner - intermediate. Version control has a great deal of useful features, but total mastery is not necessary to achieve a great deal with it. Even a beginner utilising a few of the simplest features well can save themselves a great deal of time and drastically improve the reproducibility of their work. Naturally, we encourage readers to make use of the entire chapter, but readers should not be discouraged from using some tools they feel comfortable with if they are not comfortable with *all* the tools available.
 

--- a/chapters/version_control.md
+++ b/chapters/version_control.md
@@ -2,7 +2,9 @@
 
 ## Prerequisites / recommended skill level
 
-Some experience of working via the command line is extremely helpful but not a necessity as it is possible to use version control through desktop and web browser based tools. These tools are discussed towards the end of this chapter, but the general principles and best practice discussed in the preceding sections are relevant regardless of whether the command line or a GUI is used.  
+| Prerequisite | Importance | Notes |
+| -------------|:----------:|------:|
+|Some experience of working via the command line | Extremely helpful but not a necessity as it is possible to use version control through desktop and web browser based tools | Desktop/web based tools are discussed towards the end of this chapter, but the general principles and best practice discussed in the preceding sections are relevant regardless of whether the command line or a GUI is used. |
 
 Recommended skill level: beginner - intermediate. Version control has a great deal of useful features, but total mastery is not necessary to achieve a great deal with it. Even a beginner utilising a few of the simplest features well can save themselves a great deal of time and drastically improve the reproducibility of their work. Naturally, we encourage readers to make use of the entire chapter, but readers should not be discouraged from using some tools they feel comfortable with if they are not comfortable with *all* the tools available.
 

--- a/chapters/version_control.md
+++ b/chapters/version_control.md
@@ -1,5 +1,12 @@
 # Version Control
 
+## Prerequisites / recommended skill level
+
+Some experience of working via the command line is extremely helpful but not a necessity as it is possible to use version control through desktop and web browser based tools. These tools are discussed towards the end of this chapter, but the general principles and best practice discussed in the preceding sections are relevant regardless of whether the command line or a GUI is used.  
+
+Recommended skill level: beginner - intermediate. Version control has a great deal of useful features, but total mastery is not necessary to achieve a great deal with it. Even a beginner utilising a few of the simplest features well can save themselves a great deal of time and drastically improve the reproducibility of their work. Naturally, we encourage readers to make use of the entire chapter, but readers should not be discouraged from using some tools they feel comfortable with if they are not comfortable with *all* the tools available.
+
+
 ## Summary
 
 Version control keeps track of different versions of a project and allows past versions to be accessed easily. It also allows different versions of a project to be merged with minimal input from the user. There are numerous tools available for version control such as Mercurial and SVN. The best know one is Git (and its web-based version, GitHub, which aids collaboration between researchers) which the instructions given in this chapter will be geared towards. There are a large number of detailed tutorials available online discussing the features and mechanics of how to use such systems (see the "[Further reading](#further_reading)" section at the end of the chapter.) This chapter aims to cover the general principles underpinning all version control systems, and best practice which applies for using all such systems.
@@ -10,12 +17,6 @@ Version control keeps track of different versions of a project and allows past v
 Keeping past versions of a project stored and accessible makes it possible to track its entire evolution, making the outputs far more reproducible. Version control software does this in a neat and powerful way, and it often saves researchers a great deal of time on reproducing lost code or analysis. Further, version control gives researchers more freedom to try things out and experiment. It does this by eliminating the risk of subsequent changes irrevocably 'breaking' the code as previous working versions will remain accessible regardless of how complex or how many changes are made.
 
 Another benefit of version control is that it makes collaboration easier, safer, and allows what changes have been made, when, why, and by who to be tracked. It does this by allowing different versions of a project (either two versions written by the same person, or versions from many people) to be worked on separately. It also has facilities to automatically compare and combine versions of a project, tasks which are often both fiddly and time-consuming when done manually.
-
-
-## Prerequisites / recommended skill level
-Some experience of working via the command line is extremely helpful but not a necessity as it is possible to use version control through desktop and web browser based tools. These tools are discussed towards the end of this chapter, but the general principles and best practice discussed in the preceding sections are relevant regardless of whether the command line or a GUI is used.  
-
-Recommended skill level: beginner - intermediate. Version control has a great deal of useful features, but total mastery is not necessary to achieve a great deal with it. Even a beginner utilising a few of the simplest features well can save themselves a great deal of time and drastically improve the reproducibility of their work. Naturally, we encourage readers to make use of the entire chapter, but readers should not be discouraged from using some tools they feel comfortable with if they are not comfortable with *all* the tools available.
 
 ## Version control: what it is and how it can be used to manage an evolving project
 

--- a/chapters/version_control.md
+++ b/chapters/version_control.md
@@ -3,7 +3,7 @@
 ## Prerequisites / recommended skill level
 
 | Prerequisite | Importance | Notes |
-| -------------|:----------:|------:|
+| -------------|----------|------|
 |Experience with the command line | Helpful | It is possible to use version control through desktop and web browser based tools. These are discussed towards the end of this chapter, but the general principles and best practice discussed in the preceding sections are relevant regardless of whether the command line or a GUI is used. |
 
 Recommended skill level: beginner - intermediate. Version control has a great deal of useful features, but total mastery is not necessary to achieve a great deal with it. Even a beginner utilising a few of the simplest features well can save themselves a great deal of time and drastically improve the reproducibility of their work. Naturally, we encourage readers to make use of the entire chapter, but readers should not be discouraged from using some tools they feel comfortable with if they are not comfortable with *all* the tools available.

--- a/templates/CHAPTER_TEMPLATE.md
+++ b/templates/CHAPTER_TEMPLATE.md
@@ -1,13 +1,13 @@
 # Chapter title
 
+## Prerequisites / recommended skill level
+> other chapters that should have been read before or content you should be familiar with before you read this
+
 ## Summary
 > easy to understand summary - a bit like tl;dr
 
 ## How this will help you/ why this is useful
 > why we think you should read the whole thing
-
-## Prerequisites / recommended skill level
-> other chapters that should have been read before or content you should be familiar with before you read this
 
 ## Chapter content
 > depending on the content, this might be more structured, e.g. with exercises, gotcha sections etc
@@ -27,5 +27,3 @@
 
 ## Bibliography
 > Credit/urls for any materials that form part of the chapter's text.
-
-

--- a/templates/CHAPTER_TEMPLATE.md
+++ b/templates/CHAPTER_TEMPLATE.md
@@ -4,7 +4,7 @@
 > other chapters that should have been read before or content you should be familiar with before you read this
 
 | Prerequisite | Importance | Notes |
-| -------------|:----------:|------:|
+| -------------|----------|------|
 | Chapter/topic | How important it is | Any notes |
 
 ## Summary

--- a/templates/CHAPTER_TEMPLATE.md
+++ b/templates/CHAPTER_TEMPLATE.md
@@ -2,6 +2,9 @@
 
 ## Prerequisites / recommended skill level
 > other chapters that should have been read before or content you should be familiar with before you read this
+| Prerequisite | Importance | Notes |
+| -------------|:----------:|------:|
+| Chapter/topic | How important it is | Any notes |
 
 ## Summary
 > easy to understand summary - a bit like tl;dr

--- a/templates/CHAPTER_TEMPLATE.md
+++ b/templates/CHAPTER_TEMPLATE.md
@@ -2,6 +2,7 @@
 
 ## Prerequisites / recommended skill level
 > other chapters that should have been read before or content you should be familiar with before you read this
+
 | Prerequisite | Importance | Notes |
 | -------------|:----------:|------:|
 | Chapter/topic | How important it is | Any notes |


### PR DESCRIPTION
In the chapter template and in both chapters already in master move the chapter prerequisites to the start of the chapter. Previously they came after the summary and why the chapter was useful which can be a lot of text. There's no point wasting a reader's time introducing them to a topic they do not yet have the foundations to grasp.

### What should a reviewer concentrate their feedback on?

- Whether they think this is a good idea

### Acknowledging contributors

By submitting this pull request I confirm that:

- [x] all contributors to this pull request who wish to be included are named in [humans.md](humans.md).
