### PR TITLE
Change "Open science" chapter to "Open research" chapter.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,14 @@ The Turing Way community We therefore require that all contributions **adhere to
 
 ## Inclusivity
 
-This project aims to be inclusive to people from all walks of life and to all research fields. This should be taken into account in contributions.  
+This project aims to be inclusive to people from all walks of life and to all research fields.
+This should be taken into account in contributions.
+
+The following are examples of inclusive actions that we encourage from contributors to the Turing Way:
+
+* Refer to "open research" rather than "open science" so that we do not exclude members of the humanities and social sciences from our community.
+* Make sure colour pallettes are accessible to colour-blind readers and contributors.
+  Here's a useful blog post on [tips for designing scientific figures for color blind readers](http://www.somersault1824.com/tips-for-designing-scientific-figures-for-color-blind-readers) by Luk at [Somersulat 1824](http://www.somersault1824.com).
 
 ## Get in touch
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ If you have any questions that aren't discussed below, please let us know throug
 Been here before? Already know what you're looking for in this guide? Jump to the following sections:
 
 * [Joining the community](#joining-the-community)
+* [Inclusivity](#inclusivity)
 * [Get in touch](#get-in-touch)
 * [Contributing through GitHub](#contributing-through-github)
 * [Where to start: issues](#where-to-start-issues)
@@ -23,6 +24,10 @@ Been here before? Already know what you're looking for in this guide? Jump to th
 ## Joining the community
 
 The Turing Way community We therefore require that all contributions **adhere to our [Code of Conduct](CODE_OF_CONDUCT.md)**.
+
+## Inclusivity
+
+This project aims to be inclusive to people from all walks of life and to all research fields. This should be taken into account in contributions.  
 
 ## Get in touch
 
@@ -110,11 +115,11 @@ If you feel that we should try new tools or some aspects of the collaboration co
 - On the alan turing version create a branch with the same name as the chapter to be written.
 - On your fork create a branch with the same name and create a markdown file on it.
 - Copy the chapter template in the templates directory into the markdown file, and commit.
-- Make a pull request to the turing way version of the chapter branch. 
-The title of this request should have the form "[WIP] Write Chapter_name chapter". 
+- Make a pull request to the turing way version of the chapter branch.
+The title of this request should have the form "[WIP] Write Chapter_name chapter".
 WIP indicates the chapter is a Work In Progress and not yet ready for review.
-- On your branch add material to the chapter and commit. 
-The goal of this project is to collate and build on the many good resources already available about good practise in data science. 
+- On your branch add material to the chapter and commit.
+The goal of this project is to collate and build on the many good resources already available about good practise in data science.
 As such this material should primarily be drawn from outside sources.
 Note the link and (if available) license of the source.
 - Once a significant amount of material has been amassed, work (preferably with others) to develop a chapter outline.
@@ -127,7 +132,7 @@ Note the link and (if available) license of the source.
 - Discuss and make low level changes to the chapter on this pull request, such as rewording sentences, typos and the like.
 - This division of the pull requests into high and low level changes stops discussion threads becoming unmanagably long.
 - Once this is complete merge the pull request into the alan turing intitute's version of the chapter branch.
-- Merge the alan turing intitute's version of the chapter branch into the alan turing master branch. 
+- Merge the alan turing intitute's version of the chapter branch into the alan turing master branch.
 DO not delete the branch as the chapter may continue to undergo improvement and development in the future.
 
 

--- a/chapters/open_research.md
+++ b/chapters/open_research.md
@@ -1,4 +1,4 @@
-# Open science
+# Open research
 
 ## Prerequisites / recommended skill level
 

--- a/chapters/open_research.md
+++ b/chapters/open_research.md
@@ -10,13 +10,13 @@ Recommended skill level: low.
 
 ## Summary
 
-Open science aims to transform science by making research more reproducible, transparent, re-usable, collaborative, accountable and closer to society. It pushes for change in the way that research is carried out and disseminated by digital tools. One definition of Open science, as given by the OECD [is](https://www.fct.pt/dsi/docs/Making_Open_Science_a_Reality.pdf) the practice of making "the primary outputs of publicly funded research results – publications and the research data – publicly accessible in digital format with no or minimal restriction”. In order to achieve this openness in science, each element of the research process should:
+Open research aims to transform research by making research more reproducible, transparent, re-usable, collaborative, accountable and closer to society. It pushes for change in the way that research is carried out and disseminated by digital tools. One definition of Open research, as given by the OECD [is](https://www.fct.pt/dsi/docs/Making_Open_Science_a_Reality.pdf) the practice of making "the primary outputs of publicly funded research results – publications and the research data – publicly accessible in digital format with no or minimal restriction”. In order to achieve this openness in research, each element of the research process should:
 
 - Be publicly available: it is difficult to use and benefit from knowledge hidden behind barriers such as passwords
 - Be reusable: research outputs need to be licenced appropriately so that prospective users know clearly any limitations on re-use
 - Be transparent and have appropriate metadata to provide clear statements of how research output was produced and what it contains
 
-The research process typically has the following form: data is collected, it is then analysed (usually using software). This process may involve the use of specialist hardware. The results of the research are then published. Throughout the process it is good practice for researchers to document their working in notebooks. Open science aims to make each of these elements open:
+The research process typically has the following form: data is collected, it is then analysed (usually using software). This process may involve the use of specialist hardware. The results of the research are then published. Throughout the process it is good practice for researchers to document their working in notebooks. Open research aims to make each of these elements open:
 
 - Open data - documenting and sharing research data openly for re-use
 - Open source software - documenting research code and routines, and making them freely accessible and available
@@ -26,7 +26,7 @@ The research process typically has the following form: data is collected, it is 
 
 These elements are expanded upon in this chapter.
 
-Open scholarship is a concept that extends open science further. It relates to making other aspects of scientific research open to the public, e.g.
+Open scholarship is a concept that extends open research further. It relates to making other aspects of scientific research open to the public, e.g.
 
 - Open educational resources - making educational resources publicly available to be re-used and modified.
 - Equity, diversity, inclusion - ensuring scholarship is open to anyone without barriers based on factors such as race, gender, sexual orientation, etc.
@@ -367,7 +367,7 @@ Ideally, every scientist would maintain an open notebook in real-time which woul
 
 ## Open scholarship
 
-Open science and its subcomponents fit under the umbrella of a broader concept- open scholarship.
+Open research and its subcomponents fit under the umbrella of a broader concept- open scholarship.
 
 ![open_umbrella](../figures/open_umbrella.png)
 

--- a/figures/figure_list.md
+++ b/figures/figure_list.md
@@ -8,8 +8,8 @@
 | flipped_taj_mahal          | Version control      | Upside down taj mahal to confuse people           |
 | master_branch              | Version control      | Illustrates commits on master branch              |
 | one_branch                 | Version control      | Illustrates version control master + one branch   |
-| open_access_citatations    | Open science         | Impact of openness on citation count              |
-| open_umbrella              | Open science         | Terms under the umbrella of open scholarship      |
+| open_access_citatations    | Open research        | Impact of openness on citation count              |
+| open_umbrella              | Open research        | Terms under the umbrella of open scholarship      |
 | reproducibility_kirstie    |                      | Depicts cow code and data relate to good practise |
 | sub_branch                 | Version control      | Illustrates version control branch + sub branch   |
 | two_banches                | Version control      | Illustrates version control master + two branches |


### PR DESCRIPTION
### Summary

As discussed with @pherterich in #175 it's just as important for disciplines outside of science to work openly and reproducibly, and the vast majority of the principles for doing so are the same (e.g. keep your data open, share any analysis code etc). 

As such change the open science chapter from being about open *science* to being about open *research*.

This change has been made on a new branch called open_research, which is up to date with both master and the open_science branch. If/when this pull request is accepted the open_science branch should be deleted to prevent further development on it. Future development of this chapter should take place on the open_research branch.

### List of changes proposed in this PR (pull-request)

Rename the open science chapter to open research.

Change references to "open science" within the chapter to "open research", except where specifically relevant.

Update: Also change "open science" to "open research" in figures.md which lists the figures along with the chapter they're in.

Update: Include subheading "Inclusivity" on contributions guidelines saying the project is aimed at all disciplines.

### What should a reviewer concentrate their feedback on?

Have any references been missed?

### Acknowledging contributors

<!-- Please select the box when confirmed -->

By submitting this pull request I confirm that:

- [x] all contributors to this pull request who wish to be included are named in [humans.md](humans.md).
