### PR TITLE
Remove white lines from issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,19 +1,14 @@
 <!--
 Please complete the following sections when you open an issue.
-
 You are encouraged to keep this top level comment box updated as you
 develop and respond to reviews.
-
-If you have write access to the repository please also assign the appropriate 
+If you have write access to the repository please also assign the appropriate
 label (or labels) to your issue.
-
 Note that text within html comment tags will not be rendered.
 -->
 ### Summary
 
-<!-- Please provide a detailed description of the change or addition you are proposing,
-or the question you're asking. 
-
+<!-- Please provide a detailed description of the change or addition you are proposing, or the question you're asking.
 Please provide as much context as possible and link to related issues and/or pull requests.
 -->
 
@@ -41,8 +36,7 @@ Please provide as much context as possible and link to related issues and/or pul
 
 <!-- To avoid that others have to read through the full thread of comments,
 please update the initial issue with important updates (e.g. decisions taken) regularly.
-
-You can update the task list and summary above directly (this is encouraged!) or add 
+You can update the task list and summary above directly (this is encouraged!) or add
 new information below in this new section.
 -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,7 @@
 <!--
 Please complete the following sections when you submit your pull request.
-
 You are encouraged to keep this top level comment box updated as you
 develop and respond to reviews.
-
 Note that text within html comment tags will not be rendered.
 -->
 ### Summary
@@ -28,8 +26,7 @@ Fixes #<NUM> <!-- (e.g. Fixes #58.) -->
 
 <!-- This section is particularly useful if you have a pull request that is
 still in development. You can guide the reviews to focus on the parts that are
-ready for their comments. 
-
+ready for their comments.
 We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
 
 - [ ] *Lorem ipsum dolor sit amet, consectetur adipiscing.*


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request.

You are encouraged to keep this top level comment box updated as you
develop and respond to reviews.

Note that text within html comment tags will not be rendered.
-->
### Summary

<!-- Describe the problem you're trying to fix in this pull request. Please
reference any related issue and use fixes/close to automatically close them,
if pertinent -->

Doesn't close any open issues

I find the white lines in the PR and issues templates really off putting - I don't think its clear where the html comment ends and the open text begins.

This PR removes all whitespace from inside of the html comments. The goal is to make it easier to quickly skim over the comment while still providing the information needed for new folks!

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* Remove whitespace in issue and PR templates

### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is
still in development. You can guide the reviews to focus on the parts that are
ready for their comments. 

We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [x] This is a pretty opinionated edit, so please let me know if you disagree or would want to change the templates in a different way.

### Acknowledging contributors

<!-- Please select the box when confirmed -->

By submitting this pull request I confirm that:

- [x] all contributors to this pull request who wish to be included are named in [humans.md](humans.md).