### PR TITLE
[Quick fix] Change humans.md link to contributors.md link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -39,4 +39,4 @@ We suggest using bullets (indicated by * or -) and filled checkboxes [x] here --
 
 By submitting this pull request I confirm that:
 
-- [ ] all contributors to this pull request who wish to be included are named in [humans.md](https://github.com/alan-turing-institute/the-turing-way/blob/master/humans.md).
+- [ ] all contributors to this pull request who wish to be included are named in [contributors.md](https://github.com/alan-turing-institute/the-turing-way/blob/master/contributors.md).


### PR DESCRIPTION
### Summary

Humans.md has been renamed to contributors.md. Reflect this in the pull request template.

### What should a reviewer concentrate their feedback on?

Have I missed any other links to humans.md that need fixing? I think I've checked all the files, but if you remember humans.md being referenced anywhere else please correct me.

### Acknowledging contributors

<!-- Please select the box when confirmed -->

By submitting this pull request I confirm that:

- [x] all contributors to this pull request who wish to be included are named in [humans.md](https://github.com/alan-turing-institute/the-turing-way/blob/master/humans.md).
