### PR TITLE
Make Link Destination Apparent

### DIFF
--- a/chapters/open_research.md
+++ b/chapters/open_research.md
@@ -65,7 +65,7 @@ Recommended skill level: low.
 <a name="Summary"></a>
 ## Summary
 
-Open research aims to transform research by making research more reproducible, transparent, re-usable, collaborative, accountable and closer to society. It pushes for change in the way that research is carried out and disseminated by digital tools. One definition of Open research, as given by the OECD [is](https://www.fct.pt/dsi/docs/Making_Open_Science_a_Reality.pdf) the practice of making "the primary outputs of publicly funded research results – publications and the research data – publicly accessible in digital format with no or minimal restriction”. In order to achieve this openness in research, each element of the research process should:
+Open research aims to transform research by making research more reproducible, transparent, re-usable, collaborative, accountable and closer to society. It pushes for change in the way that research is carried out and disseminated by digital tools. One definition of Open research, [as given by the Organisation for Economic Co-operation and Development (OECD)](https://www.fct.pt/dsi/docs/Making_Open_Science_a_Reality.pdf "Making Open Science a Reality, OECD Science, Technology and Industry Policy Papers No. 25"), is the practice of making "the primary outputs of publicly funded research results – publications and the research data – publicly accessible in digital format with no or minimal restriction”. In order to achieve this openness in research, each element of the research process should:
 
 - Be publicly available: it is difficult to use and benefit from knowledge hidden behind barriers such as passwords
 - Be reusable: research outputs need to be licenced appropriately so that prospective users know clearly any limitations on re-use


### PR DESCRIPTION
### Summary
In the first paragraph of the **Open Research** chapter, there is a link to a paper defining the term *open research*.  The link text in the sentence is the single word *is*.  This is bad practice because it gives the reader little indication as to where the linking is pointing.  Instead the link text should give some indication of what material is being linked, which is what this PR proposes.

### List of changes proposed in this PR (pull-request)
*  Make the link text the handful of words earlier in the sentence.
*  Spell out what OECD stands for in case readers don't know.
*  Include additional information (in this case the name of the paper and its source) in the link mouseover text.

### Acknowledging contributors

By submitting this pull request I confirm that:

- [x] all contributors to this pull request who wish to be included are named in [contributors.md](https://github.com/alan-turing-institute/the-turing-way/blob/master/contributors.md).

Nope, but I am listed as a contributor on the `README.md`.