### PR TITLE
Remove Unnecessary Section Anchors

### DIFF
--- a/chapters/open_research.md
+++ b/chapters/open_research.md
@@ -11,58 +11,57 @@ Recommended skill level: low.
 
 ## Table of contents
 
-1. [Summary](#Summary)
-2. [How this will help you/ why this is useful](#Why_this_is_useful)
-3. [Open data](#Open_data)
-    1. [Steps to make your data open](#Steps_to_make_your_data_open)
-        1. [Step 1: Make your data available](#Step_1_Make_your_data_available)
-        2. [Step 2: Make your data easy to understand](#Step_2_Make_your_data_easy_to_understand)
-        3. [Step 3: Make your data easy to use](#Step_3_Make_your_data_easy_to_use)
-        4. [Step 4: Make your data citeable](#citing_data)
-    2. [Barriers to data sharing](#Barriers_to_data_sharing)
-        1. [Privacy](#Privacy)
-        2. [National and commercially sensitive data](#National_and_commercially_sensitive_data)
-4. [Open source software](#Open_source_software)
-    1. [What is open source software](#What_is_open_source_software)
-    2. [How running and contributing to open source software projects benefits you](#How_running_and_contributing_to_open_source_software_projects_benefits_you)
-        1. [Making your own work open source](#Making_your_own_work_open_source)
-        2. [Contributing to others' open source software projects](#Contributing_to_others_open_source_software_projects)
-    3. [How open source software benefits research](#How_open_source_software_benefits_research)
-    4. [How to run your own open source software project](#How_to_run_your_own_open_source_software_project)
-        1. [Readme](#Readme)
-        2. [Contributing guidelines](#Contributing_guidelines)
-        3. [Code of conduct](#Code_of_conduct)
-    5. [How to contribute to other's open source software projects](#How_to_contribute_to_others_open_source_software_projects)
-        1. [Anatomy of an open source software project](#Anatomy_of_an_open_source_software_project)
-        2. [Contribute your changes](#Contribute_your_changes)
-        3. [Looking for projects to contribute to and how to contribute to them](#Looking_for_projects_to_contribute_to_and_how_to_contribute_to_them)
-5. [Open hardware](#Open_hardware)
-    1. [Why open hardware?](#Why_open_hardware)
-    2. [Elements of an open source hardware project](#Elements_of_an_open_source_hardware_project)
-    3. [Open source hardware processes and practices](#Open_source_hardware_processes_and_practices)
-        1. [Designing your hardware](#Designing_your_hardware)
-        2. [Hosting your design file](#Hosting_your_design_files)
-        3. [Distributing open source hardware](#Distributing_open_source_hardware)
-6. [Open access](#Open_access)
-    1. [What is open access?](#What_is_open_access)
-        1. [Repositories and self-archiving](#Repositories_and_self_archiving)
-        2. [Open access publishing](#Open_access_publishing)
-    2. [Why does open access matter?](#Why_does_open_access_matter)
-    3. [Best practice for open access](#Best_practice_for_open_access)
-        1. [Self-archiving](#Self_archiving)
-        2. [Publication](#Publication)
-7. [Open notebooks](#Open_notebooks)
-8. [Open scholarship](#Open_scholarship)
-    1. [Open educational resources](#Open_educational_resources)
-    2. [Equity, Diversity, Inclusion](#Equity_Diversity_Inclusion)
-    3. [Citizen science](#Citizen_science)
-9. [Checklists](#Checklists)
-10. [What to learn next](#What_to_learn_next)
-11. [Further reading](#Further_reading)
-12. [Definitions/glossary](#Glossary)
-13. [Bibliography](#Bibliography)
+1. [Summary](#summary)
+2. [How this will help you/ why this is useful](#how-this-will-help-you-why-this-is-useful)
+3. [Open data](#open-data)
+    1. [Steps to make your data open](#steps-to-make-your-data-open)
+        1. [Step 1: Make your data available](#step-1-make-your-data-available)
+        2. [Step 2: Make your data easy to understand](#step-2-make-your-data-easy-to-understand)
+        3. [Step 3: Make your data easy to use](#step-3-make-your-data-easy-to-use)
+        4. [Step 4: Make your data citeable](#step-4-make-your-data-citeable)
+    2. [Barriers to data sharing](#barriers-to-data-sharing)
+        1. [Privacy](#privacy)
+        2. [National and commercially sensitive data](#national-and-commercially-sensitive-data)
+4. [Open source software](#open-source-software)
+    1. [What is open source software?](#what-is-open-source-software)
+    2. [How running and contributing to open source software projects benefits you](#how-running-and-contributing-to-open-source-software-projects-benefits-you)
+        1. [Making your own work open source](#making-your-own-work-open-source)
+        2. [Contributing to others' open source software projects](#contributing-to-others-open-source-software-projects)
+    3. [How open source software benefits research](#how-open-source-software-benefits-research)
+    4. [How to run your own open source software project](#how-to-run-your-own-open-source-software-project)
+        1. [Welcome users by adding information to your README](#welcome-users-by-adding-information-to-your-readme)
+        2. [Contributing guidelines](#contributing-guidelines)
+        3. [Code of conduct](#code-of-conduct)
+    5. [How to contribute to other's open source software projects](#how-to-contribute-to-others-open-source-software-projects)
+        1. [Anatomy of an open source software project](#anatomy-of-an-open-source-software-project)
+        2. [Contribute your changes](#contribute-your-changes)
+        3. [Looking for projects to contribute to and how to contribute to them](#looking-for-projects-to-contribute-to-and-how-to-contribute-to-them)
+5. [Open hardware](#open-hardware)
+    1. [Why open hardware?](#why-open-hardware)
+    2. [Elements of an open source hardware project](#elements-of-an-open-source-hardware-project)
+    3. [Open source hardware processes and practices](#open-source-hardware-processes-and-practices)
+        1. [Designing your hardware](#designing-your-hardware)
+        2. [Hosting your design file](#hosting-your-design-files)
+        3. [Distributing open source hardware](#distributing-open-source-hardware)
+6. [Open access](#open-access)
+    1. [What is open access?](#what-is-open-access)
+        1. [Repositories and self-archiving](#repositories-and-self-archiving)
+        2. [Open access publishing](#open-access-publishing)
+    2. [Why does open access matter?](#why-does-open-access-matter)
+    3. [Best practice for open access](#best-practice-for-open-access)
+        1. [Self-archiving](#self-archiving)
+        2. [Publication](#publication)
+7. [Open notebooks](#open-notebooks)
+8. [Open scholarship](#open-scholarship)
+    1. [Open educational resources](#open-educational-resources)
+    2. [Equity, Diversity, Inclusion](#equity-diversity-inclusion)
+    3. [Citizen science](#citizen-science)
+9. [Checklists](#checklists)
+10. [What to learn next](#what-to-learn-next)
+11. [Further reading](#further-reading)
+12. [Definitions/glossary](#definitions-glossary)
+13. [Bibliography](#bibliography)
 
-<a name="Summary"></a>
 ## Summary
 
 Open research aims to transform research by making research more reproducible, transparent, re-usable, collaborative, accountable and closer to society. It pushes for change in the way that research is carried out and disseminated by digital tools. One definition of Open research, as given by the OECD [is](https://www.fct.pt/dsi/docs/Making_Open_Science_a_Reality.pdf) the practice of making "the primary outputs of publicly funded research results – publications and the research data – publicly accessible in digital format with no or minimal restriction”. In order to achieve this openness in research, each element of the research process should:
@@ -89,7 +88,6 @@ Open scholarship is a concept that extends open research further. It relates to 
 
 These elements are also discussed in detail in this chapter.
 
-<a name="Why_this_is_useful"></a>
 ## How this will help you/ why this is useful
 
 There are five main schools of thought motivating open practices to benefit research:
@@ -110,7 +108,6 @@ Open practices also benefit the researchers that propagate them. For example the
 
 Another benefit of openness is that while research collaborations are essential to advancing knowledge, identifying and connecting with appropriate collaborators is not trivial. Open practices can make it easier for researchers to connect with one another by increasing the discoverability and visibility of one’s work, facilitating rapid access to novel data and software resources, and creating new opportunities to interact with and contribute to ongoing communal projects.
 
-<a name="Open_data"></a>
 ## Open data
 
 The world is witnessing a significant global transformation, facilitated by technology and digital media, and fuelled by data and information. This transformation has enormous potential to foster more transparent, accountable, efficient, responsive, and effective research.
@@ -124,28 +121,23 @@ Open data is freely available on the internet and any user is permitted to downl
 This represents a real shift in how research works. At the moment anyone who wishes to use data from a researcher often has to contact that researcher and make a request. "Open by default" turns this on its head and says that there should be a presumption of publication for all. If access to data is restricted, for instance due to security reasons, the justification for this should be made clear.
 Free access to, and subsequent use of, data is of significant value to society and the economy, and that data should, therefore, be open by default. So, how do you go about making your data open?
 
-<a name="Steps_to_make_your_data_open"></a>
 ### Steps to make your data open
 
-<a name="Step_1_Make_your_data_available"></a>
 #### Step 1: Make your data available
 
 Put your data online. It should be easily discoverable and accessible, and made available without bureaucratic or administrative barriers, which can deter people from accessing the data. Choose a location to store the data which will ensure historical copies of datasets are preserved, archived, and kept accessible as long as they retain value. Whenever possible, researchers should provide data in its original, unmodified form.
 
 Data should be free of charge, under [an open licence](https://fossbytes.com/open-sources-license-type/), (for example, those developed by Creative Commons) so it can be reused and remixed by other researchers. The data should be available as a whole and at no more than a reasonable reproduction cost i.e. no expensive piece of software should be required to read the file as this may obstruct researchers who wish to work with the dataset.
 
-<a name="Step_2_Make_your_data_easy_to_understand"></a>
 #### Step 2: Make your data easy to understand
 
 Having data available is of no use if it cannot be understood. For example, a table of numbers is useless if there are no headings which describe the contents of the rows and columns. Therefore you should ensure that open datasets include consistent core metadata, and that the data is fully described. This requires that all documentation accompanying data is written in clear, plain language, and that data users have sufficient information to understand the source, strengths, weaknesses, and analytical limitations of the data so that they can make informed decisions when using it.
 
-<a name="Step_3_Make_your_data_easy_to_use"></a>
 #### Step 3: Make your data easy to use
 
 The data should be made available in a modifiable, machine-readable format so that it can be effectively used and  manipulated.
 It is also important to think about the file formats that information is provided in. Data should be presented in structured and standardized formats to support interoperability, traceability, and effective reuse. In many cases, this will include providing data in multiple, standardized formats, so that it can be processed by computers and used by people.
 
-<a name="citing_data"></a>
 #### Step 4: Make your data citeable
 
 Data should be considered a legitimate, citable product of research. Making data citeable (and citing data yourself) facilitates the giving of scholarly credit; in scholarly literature, whenever and wherever a claim relies upon data, the corresponding data should be cited. Data citations facilitate identification of, access to, and verification of the specific data that support a claim, making it possible to reproduce the underlying analysis. You should ensure that anyone who wishes to cite a dataset that you host has access to a persistent identifier in order to do so.
@@ -159,12 +151,10 @@ When organisations register a DOI for a resource, they should not introduce sema
 
 Whichever identifier scheme you pick make sure it allows the identifier to be resolved to a URL. This URL should belong to a landing page that contains descriptive information about the dataset, as well as links or instructions for accessing it. You should also ensure that datasets are made citable and identifiable at an appropriate level of granularity, i.e. it would be no use citing CERN's entire data repository as someone attempting to reproduce your work would not be able to find the data used in a specific piece of work without considerable difficulty. Where possible it should be possible to cite the data used, and only the data used.
 
-<a name="Barriers_to_data_sharing"></a>
 ### Barriers to data sharing
 
 Sometimes it may not be possible to make data publicly available in its entirety or even in part. There are two main reasons this may be the case:
 
-<a name="Privacy"></a>
 #### Privacy
 
 Many fields of research involve working with sensitive personal data, medical research being the most obvious example.
@@ -172,17 +162,14 @@ Individuals must be protected from (re)identification via their personal data us
 
 Preserving privacy may still be possible if partial or generalised datasets are provided e.g. age bands instead of birth date or only the first two digits of postal codes. It may also be possible to provide the data in such a format that researchers can query it whist keeping the data itself closed, e.g. a user may be able to send a query to retrieve the mean of a dataset, but not be able to access any of the individual datapoints.
 
-<a name="National_and_commercially_sensitive_data"></a>
 #### National and commercially sensitive data
 
 In many cases companies are understandably unwilling to publish much of their data. The reasoning goes that if commercially sensitive information of a company is disclosed, it will damage the company’s commercial interests and undermine competitiveness. This is based on the thinking that in competitive markets, innovation will only occur with some protection of information: if a company spends time and money developing something new, the details of which are then made public, then its competitors can easily copy it without having to invest the same resources. The result is that no-one would innovate in the first place. Similarly, governments are often unwilling to publish data that relates to issues such as national security due to public safety concerns.
 
 In such cases it may not be possible to make data open, or it may only be only possible to share partial/obscured datasets as outlined in the section above on privacy.
 
-<a name="Open_source_software"></a>
 ## Open source software
 
-<a name="What_is_open_source_software"></a>
 ### What is open source software?
 
 When a project is open source anybody can view, use, modify, and distribute the project for any purpose. These permissions are enforced through an open source licence. Open source is powerful because it lowers the barriers to adoption, allowing ideas to spread quickly. In its most basic form, open sourcing your software simply means putting your code online where it can be viewed and reused by others.
@@ -191,7 +178,6 @@ Many of the most widely used research software is open source. Perhaps the parad
 
 Researchers that make use of open source software often make changes to them such as adding features they need for their own research, or fixing bugs. They can then contribute these improvements back to the main project so the wider community can take advantage of them.
 
-<a name="How_running_and_contributing_to_open_source_software_projects_benefits_you"></a>
 ### How running and contributing to open source software projects benefits you
 
 - Improve existing skills. Whether it’s coding, user interface design, graphic design, writing, or organizing, if you’re looking for practice, there’s a task for you on an open source software project. Further, open source necessitates cleaner, more maintainable code to enable collaboration between potentially thousands of people who may never meet. This helps to build and maintain good coding habits. Not to be underestimated are the people skills you can develop on open source software projects.
@@ -202,7 +188,6 @@ Open source offers opportunities to practice leadership and management skills, s
 - Meet people who are interested in similar things. Open source software projects with warm, welcoming communities keep people coming back for years and many people form lifelong friendships through their participation in open source.
 - Find mentors and teach others. Working with others on a shared project means you’ll have to explain how you do things, as well as ask other people for help. The acts of learning and teaching can be a fulfilling activity for everyone involved.
 
-<a name="Making_your_own_work_open_source"></a>
 #### Making your own work open source
 
 - Making your work openly available for re-use makes it easier for others to incorporate into their own research. If you make your software citeable, for example via a [DOI](doi_system) this can increase your citations.
@@ -210,28 +195,24 @@ Open source offers opportunities to practice leadership and management skills, s
 - Feedback. Making your work open enables you to get feedback and improve your project in way you may never have thought of alone.
 - Accountability. There is an argument that any software developed using government money should be open source by default- if the public has paid for its development they have a right to make use of it. If your work is government funded making it open is a step you can take towards government openness and accountability.
 
-<a name="Contributing_to_others_open_source_software_projects"></a>
 #### Contributing to others' open source software projects
 
 - It’s empowering to be able to make changes, even small ones. You don’t have to become a lifelong contributor to enjoy participating in open source. Have you ever seen a typo on a website, and wished someone would fix it? On an open source software project, you can do just that. Open source helps people feel agency over their lives and how they experience the world, and that in itself is gratifying.
 - It's fun. Open source provides an endless, ever-changing set of Rubix cubes for you to solve on weekends. Just like puzzles, both crossword and jigsaw, open source provides bite-sized intellectual escapes.
 
-<a name="How_open_source_software_benefits_research"></a>
 ### How open source software benefits research
 
 Open source software projects primarily benefit research by allowing researchers to take advantage of each other's work. This enables researchers to apply their efforts to  high-value work. It is sometimes said that "all the easy problems have already been solved". Blogging, content management, and operating systems are all problems with established (and mainstream) open source solutions, to name a few. While developers could spend their time reinventing wheels that the open source community have already perfected, it's far preferable to use the world's best wheel, especially when that wheel comes at no cost to you. This frees researchers up to work on yet-unsolved challenges. This reduces duplication of effort and allows researchers to focus on the work they're actually interested in.
 
 Working openly also allows any number of researchers to collaborate on projects that could not possibly be developed by single researchers/research groups. Examples include [Linux](https://www.linux.org/) operating systems, Python packages such as [scipy](https://www.scipy.org/) and [numpy](http://www.numpy.org/), and the machine learning library [TensorFlow](https://www.tensorflow.org/).    
 
-<a name="How_to_run_your_own_open_source_software_project"></a>
 ### How to run your own open source software project
 
 You can open source an idea, a work in progress, or after years of being closed source. At the most basic level all you need to do is put your code online somewhere that is likely to last a long time. You can make your code citeable by assigning it a DOI (as discussed in the section on [making data citeable](#citing_data)). This helps ensure that you get proper credit if people use or build upon your work.
 
 A popular place to make your code available is GitHub (see the chapter on version control). You must include a licence file stating that anyone has permission to use, copy and modify your work. Without this no one can legally use your work and so it isn't open source. [This](https://choosealicense.com/) website offers a very simple mechanism to help you pick the best licence for your project. There are also a few other files you should include with your code:
 
-<a name="Readme"></a>
-#### Readme
+#### Welcome users by adding information to your README
 
 You should include a readme file where you include useful information about what the project is, how to use it and how to contribute to it. Here's a list of the main things a readme should include:
 
@@ -246,7 +227,6 @@ The best thing you can do is to just write up the installation instructions when
 
 If you intend for other people to collaborate on your project (as opposed to just making your code available and considering it complete) then you should include contributing guidelines and most likely a code of conduct.
 
-<a name="Contributing_guidelines"></a>
 #### Contributing guidelines
 
 Contributing guidelines tell your audience how to participate in your project. For example, you might include information on:
@@ -260,7 +240,6 @@ Using a warm, friendly tone and offering specific suggestions for contributions 
 
 In the earliest stages of your project, your contributing guidelines file can be simple. You should always explain how to report bugs or file issues, and any technical requirements (like tests) to make a contribution. Over time, you might add other frequently asked questions here or in your readme file. Writing down this information means fewer people will ask you the same questions over and over again. It's also a good idea to link to your contributing guidelines file from your readme, so more people see it.
 
-<a name="Code_of_conduct"></a>
 #### Code of conduct
 
 A code of conduct helps set ground rules for behaviour for your project's participants. This is especially valuable if you're launching an open source project for a community or company. A code of conduct empowers you to facilitate healthy, constructive community behaviour, which will reduce your stress as a maintainer. In addition to communicating how you expect participants to behave, a code of conduct also tends to describe who these expectations apply to, when they apply, and what to do if a violation occurs.
@@ -270,10 +249,8 @@ Much like open source licences, there are also emerging standards for codes of c
 Keep the file in your project's root directory so it's easy to find, and link to it from your readme.
 
 
-<a name="How_to_contribute_to_others_open_source_software_projects"></a>
 ### How to contribute to other's open source software projects
 
-<a name="Anatomy_of_an_open_source_software_project"></a>
 #### Anatomy of an open source software project
 
 Every open source community is different. That said, many open source software projects follow a similar organizational structure. Understanding the different community roles and overall process will help you get quickly oriented to any new project.
@@ -295,7 +272,6 @@ A great many open source projects are hosted on GitHub (see the chapter on versi
 - Discussion forums or mailing lists: Some projects may use these channels for conversational topics (for example, "How do I…" or "What do you think about…" instead of bug reports or feature requests). Others use the issue tracker for all conversations.
 - Synchronous chat channel: Some projects use chat channels (such as Slack or IRC) for casual conversation, collaboration, and quick exchanges.
 
-<a name="Contribute_your_changes"></a>
 #### Contribute your changes
 
 Say you've added a feature or fixed a bug and want to contribute this work to the main project.
@@ -308,7 +284,6 @@ Say you've added a feature or fixed a bug and want to contribute this work to th
 6. Ask questions. If there are things you are unsure about there's no harm in asking. Many larger projects have dedicated forums or other venues for questions and discussion.
 7. When you submit your changes clearly describe the changes you've made, why you've made them, and how they have been implemented. This makes it as easier for someone looking at your work and deciding whether to incorporate it into the main project to do so. In the likely case the main project is hosted on GitHub you should put this in the pull request (see the version control chapter for more details).
 
-<a name="Looking_for_projects_to_contribute_to_and_how_to_contribute_to_them"></a>
 #### Looking for projects to contribute to and how to contribute to them
 
 You don’t need to overthink what exactly your first contribution will be, or how it will look. Instead, start by thinking about the projects you already use, or want to use. The projects you’ll actively contribute to are the ones you find yourself coming back to. Within those projects, whenever you catch yourself thinking that something could be better or different, act on your instinct. You might scan a readme and find a broken link or a typo. Or you’re a new user and you noticed something is broken, or an issue that you think should really be in the documentation. Instead of ignoring it and moving on, or asking someone else to fix it, see whether you can help out by pitching in. That’s what open source is all about!
@@ -333,7 +308,6 @@ A common misconception about contributing to open source is that you need to con
     - Going through open issues and suggesting closing old ones
     - Ask clarifying questions on recently opened issues to move the discussion forward
 
-<a name="Open_hardware"></a>
 ## Open hardware
 
 "Open hardware," or "open source hardware," refers to the design specifications of a physical object which are licenced in such a way that said object can be studied, modified, created, and distributed by anyone. Like open source software, the "source code" for open hardware—schematics, blueprints, logic designs, Computer Aided Design (CAD) drawings or files, etc.—is available for modification or enhancement by anyone. Users with access to the tools that can read and manipulate these source files can update and improve the physical device and the code that underlies it, and, if they wish, proceed to share such modifications.
@@ -343,14 +317,12 @@ Open hardware's source code should be readily accessible, and its components are
 It's worth noting that open hardware does not necessary mean free. Units may still be sold (by the original designer or by others), but users *could* build them from scratch. Whether or not they choose to buy the unit, users can still get a full understanding of how the hardware works from open documentation, designs, etc.  
 
 
-<a name="Why_open_hardware"></a>
 ### Why open hardware?
 
 Open hardware allows researchers to understand exactly what their equipment is doing, how it's doing it, and to verify that is doing it correctly rather than having to extend a degree of trust. Being aware of how the equipment that generates a result works puts researchers on a firmer footing in assessing those results. Open hardware also makes research more reproducible as researchers looking to verify results can do the same thing.
 
 Other benefits of open hardware include protection against lock-in. Proprietary software for core infrastructure increases the risk of becoming locked in by the vendor or technology. If this happens, researchers can be at the mercy of vendors' price increases and experience a lack of flexibility they can't easily and readily escape. Further, if researchers want to modify their equipment to better suit their needs it is much easier to do so (and may only be legal) in the case of open source hardware.
 
-<a name="Elements_of_an_open_source_hardware_project"></a>
 ### Elements of an open source hardware project
 
 Here are some files that you should consider sharing when publishing your open source hardware project. You are not required to post them all, but the more you share the more the community benefits. There is a lot of crossover here with files to include in open source software projects.
@@ -375,10 +347,8 @@ Here are some files that you should consider sharing when publishing your open s
   - Keep in mind that these instructions may be read by someone whose expertise or training is different from yours. As much as possible, try to write to a general audience, and check your instructions for industry jargon, be explicit about what you assume the user knows, etc.
   - The instructions could be in a variety of formats, like a wiki, text file, Google Doc, or PDF. Remember, though, that others might want to modify your instructions as they modify your hardware design, so it’s good to provide the original editable files for your documentation, not just output formats like PDF.
 
-<a name="Open_source_hardware_processes_and_practices"></a>
 ### Open source hardware processes and practices
 
-<a name="Designing_your_hardware"></a>
 #### Designing your hardware
 
 If you’re planning to open source a particular piece of hardware, following certain best practices in its design will make it easier for others to make and modify the hardware:
@@ -387,12 +357,10 @@ Use free and open source software design (CAD) tools where possible. If that’s
 
 Use standard and widely-available components, materials, and production processes. Try to avoid parts that aren’t available to individual customers or processes that require expensive setup costs.
 
-<a name="Hosting_your_design_files"></a>
 #### Hosting your design files
 
 A basic way of sharing your files is with a zip file on your website. While this is a great start, it makes it difficult for others to follow your progress or to contribute improvements. Using an online source-code repository (like GitHub, GitLab, or NotaBug) may be a better place to store your open source hardware projects.
 
-<a name="Distributing_open_source_hardware"></a>
 #### Distributing open source hardware
 
 - Provide links to the source (original design files) for your hardware on the product itself, its packaging, or its documentation.
@@ -400,15 +368,12 @@ A basic way of sharing your files is with a zip file on your website. While this
 - Label the hardware with a version number or release date so that people can match the physical object with the corresponding version of its design files.
 - In general, clearly indicate which parts of a product are open source (and which aren’t).
 
-<a name="Open_access"></a>
 ## Open access
 
-<a name="What_is_open_access"></a>
 ### What is open access?
 
 One of the most common ways to disseminate research results is by writing a manuscript and publishing it in a journal, conference proceedings or book. For many years those publications were available to the public if purchased by means of a subscription fee or individually. However, new knowledge is built by synthesizing current scholarship and then building upon it. At the turn of the 21st century a new movement appeared with a clear objective: make all the research results available to anyone interested in reading it, free of charge by any user, with no technical obstacles such as mandatory registration or login to specific platforms. This movement took the name of Open access and established two initial strategies to achieve its final goal: self-archiving and open access publishing.
 
-<a name="Repositories_and_self_archiving"></a>
 #### Repositories and self-archiving
 
 The aim of the self-archiving movement is to provide tools and assistance to scholars to deposit their refereed journal articles in open electronic repositories.  As a result of the first strategy we see self-archiving practices: researchers depositing and disseminating papers in institutional or subject based repositories. There has also been a growth in the publication of preprints through institutional repositories and preprint servers. Preprints are widely used in physical sciences and now emerging in life sciences and other fields. Preprints are documents that have not been peer reviewed but are considered as a complete publication in a first stage. Some of the preprint servers include open peer review services and the availability to post new versions of the initial paper once reviewed by peers.
@@ -421,7 +386,6 @@ Regarding the version, some journals allow the dissemination of the submitted ve
 
 In relation to the moment to make the paper publicly available, many journals establish a period of time from its original publication: the embargo period, which can range from zero to 60 months when making the paper publicly available is not permitted. Some journals include or exclude embargoes depending on the versions. For instance the accepted version could be made publicly available after publication but the published version must wait 12 months.
 
-<a name="Open_access_publishing"></a>
 #### Open access publishing
 
 Open access publishing attempts to ensure permanent open access to all the articles published in journals, and as a result we have seen the creation of the open access journals. The number of open access journals has increased during the last years, according to the Directory of Open access Journals \([DOAJ](http://www.doaj.org)\), currently there are more than 12,000. Open access journal must provide free access to its contents but it also must licence them to allow reusability.
@@ -430,25 +394,20 @@ Currently many paywalled journals offer individual open access options to resear
 
 Open access publishing has two primary versions—gratis and libre. Gratis open access is simply making research available for others to read without having to pay for it. However, it does not grant the user the right to make copies, distribute, or modify the work in any way beyond fair use. Libre open access is gratis, meaning the research is available free of charge, but it goes further by granting users additional rights, usually via a Creative Commons licence, so that people are free to reuse and remix the research. There are varying degrees of what may be considered libre open access. For example, some scholarly articles may permit all uses except commercial use, some may permit all uses except derivative works, and some may permit all uses and simply require attribution. While some would argue that libre open access should be free of any copyright restrictions (except attribution), other scholars consider a work that removes at least some permission barriers to be libre.
 
-<a name="Why_does_open_access_matter"></a>
 ### Why does open access matter?
 
 Research is useless if it’s not shared; even the best research is ineffectual if others aren’t able to read and build on it. When price barriers keep articles locked away, research cannot achieve its full potential. Open access benefits researchers who can work more effectively with a better understanding of the literature. It also helps avoid duplication of effort. No researcher (or funder) wants to waste time and money conducting a study if they know it has been attempted elsewhere. But, duplication of effort is all-too-possible when researchers can’t effectively communicate with one another and make results known to others in their field and beyond. It also benefits researchers by providing better visibility and therefore higher impact/citation rate for their scholarship.  Numerous publishers, both non-profit and for-profit, voluntarily make their articles openly available at the time of publication or within 6-12 months.  Many have switched from a closed, subscription model to an open one as a strategic business decision to increase their journal's exposure and impact. Further it can be argued that taxpayers who pay for much of the research published in journals have a right to access the information resulting from that investment without charge. Finally, if research is available to the widest possible pool of readers then it is more likely/easy for it to be checked and reproduced.  
 
-<a name="Best_practice_for_open_access"></a>
 ### Best practice for open access
 
-<a name="Self_archiving"></a>
 #### Self-archiving
 
 Self-archive a publication in a suitable repository, institutional or subject-based, following the possible restrictions posed by the publisher, e.g. an embargo period, or limits on the allowed version to be deposited in such archives. In doing this it is important to make sure you are aware of the copyright implications of any documents/agreements you make when submitting your manuscript to a journal. If your institution does not have an institutional repository, advocate for the creation of one.
 
-<a name="Publication"></a>
 #### Publication
 
 Consider submitting your work to a journal that is open access. When doing this be aware that there may be funds or discounts available to cover any associated costs.
 
-<a name="Open_notebooks"></a>
 ## Open notebooks
 
 Electronic Lab Notebooks (ELNs) enable researchers to organize and store experimental procedures, protocols, plans, notes, data, and even unfiltered interpretations using their computer or mobile device. They are a digital analogue to the paper notebook most researchers keep. ELNs can offer several advantages over the traditional paper notebook in documenting research during the active phase of a project, including searchability within and across notebooks, secure storage with multiple redundancies, remote access to notebooks, and the ability to easily share notebooks among team members and collaborators.
@@ -459,14 +418,12 @@ Open notebooks have the further benefit of increasing the quality of scientific 
 
 Ideally, every scientist would maintain an open notebook in real-time which would encompass all aspects of their research. But many fears about dealing with complete open access, conflicts with intellectual property and publications, and online data overload hamper this movement. To combat this, practitioners encourage any form of open notebook research, "make open what you can", even if that means uploading some information for a project from many years ago that never saw the light of day.
 
-<a name="Open_scholarship"></a>
 ## Open scholarship
 
 Open research and its subcomponents fit under the umbrella of a broader concept- open scholarship.
 
 ![open_umbrella](../figures/open_umbrella.png)
 
-<a name="Open_educational_resources"></a>
 ### Open educational resources
 
 Open Educational Resources (OER) are teaching and learning materials that can be freely used and reused for learning and/or teaching at no cost, and without needing to ask permission. Examples are courses- including MOOCs (Massive Online Open Course), lectures, teaching materials, assignments and various other resources. OERs are available in many different formats compatible with online usage, most obviously text, images, audio and video. Anyone with internet access can access and use OERs; access is not dependent on location or membership of a particular institution.
@@ -489,19 +446,16 @@ Researchers generate a great deal of educational resources in the course of teac
 
 Beyond the raw practical benefits the worldwide OER movement is rooted in the human right to access high-quality education. This shift in educational practice is about participation and co-creation. Open Educational Resources (OER) offer opportunities for systemic change in teaching and learning content through engaging educators in new participatory processes and effective technologies for engaging with learning.
 
-<a name="Equity_Diversity_Inclusion"></a>
 ### Equity, Diversity, Inclusion
 
 Open scholarship means open to *everyone* without discrimination based on factors such as race, gender, sexual orientation or any number of other factors. As a community we should undertake to ensure equitable opportunities for all. We can go about that by deliberately fostering welcoming, inclusive cultures within out communities. For example, reasonable accommodations should be made wherever possible to include community members with disabilities to enable them to participate fully, and this can be as simple as choosing colourblind-safe colour schemes when making graphs.
 
-<a name="Citizen_science"></a>
 ### Citizen science
 
 Citizen science is the involvement of the public in scientific research – whether community-driven research or global investigations, the Oxford English Dictionary recently defined it as: "scientific work undertaken by members of the general public, often in collaboration with or under the direction of professional scientists and scientific institutions." Citizen science offers the power of science to everyone, and the power of everyone to science.
 
 By allowing members of the public to contribute to scientific research, citizen science helps engage and invest the wider world in science. It also benefits researchers by offering manpower that simply wouldn't be accessible otherwise. Examples of this include [finding](https://citizensciencegames.com/games/eterna/) ways of folding molecules, and [classifying](https://www.zooniverse.org/) different types of galaxies.
 
-<a name="Checklists"></a>
 ## Checklists
 
 ### Open data
@@ -535,17 +489,14 @@ By allowing members of the public to contribute to scientific research, citizen 
 - [ ] Keep notes in an Electronic Lab Notebook
 - [ ] Make your notebooks publicly accessible online.
 
-<a name="What_to_learn_next"></a>
 ## What to learn next
 
 If you haven't had a chance already, take a look at the chapter on version control, particularly the sections on GitHub in the latter half.
 
-<a name="Further_reading"></a>
 ## Further reading
 
 [This](http://book.openingscience.org.s3-website-eu-west-1.amazonaws.com/) book on open science has a great deal of interesting information. For information specific to open source software [this](https://opensource.guide/) is a good place to look. For more information on DOIs and citing resources look [here](http://www.doi.org/index.html). If you want to take a look at an active open source project this textbook *is* one. The source can be found on GitHub [here](https://github.com/alan-turing-institute/the-turing-way) and for further details related to this project you can take a look at the project [website](https://www.turing.ac.uk/research/research-projects/turing-way-handbook-reproducible-data-science).
 
-<a name="Glossary"></a>
 ## Definitions/glossary
 
 **Citizen science:** The involvement of members of the public in scientific research.
@@ -584,7 +535,6 @@ If you haven't had a chance already, take a look at the chapter on version contr
 
 **Self-archive:** To place your research output in a repository.
 
-<a name="Bibliography"></a>
 ## Bibliography
 - [1.](https://www.fosteropenscience.eu/content/what-open-science-introduction) **CC-BY 4.0**
 - [2.](https://open-science-training-handbook.gitbook.io/book/introduction) **CC 1.0**

--- a/chapters/version_control.md
+++ b/chapters/version_control.md
@@ -10,82 +10,77 @@ Recommended skill level: beginner - intermediate. Version control has a great de
 
 ## Table of contents
 
-1. [Summary](#Summary)
-2. [How version control is helpful](#How_version_control_is_helpful)
-3. [Version control: what it is and how it can be used to manage an evolving project](#what_version_control_is_and_how_it_can_be_used)
-    1. [What it is](#what_it_is)
-    2. [The basic workflow](#The_basic_workflow)
-    3. [Other facilities offered by version control](#branches_overview)
-4. [Why should you use version control?](#Why_should_you_use_version_control)
-5. [Getting Started](#Getting_started)
-6. [Commits](#Commits)
-    1. [The problem](#Commits_the_problem)
-    2. [The solution](#Commits_the_solution)
-    3. [How to do it](#adding)
-        1. [Retrieving past versions](#Retrieving_past_versions)
-    4. [Good practice](#Commits_good_practice)
-7. [Commit messages](#commit_messages)
-    1. [The problem](#Commit_messages_the_problem)
-    2. [The solution](#Commit_messages_the_solution)
-    3. [How to do it](#Commit_messages_how_to_do_it)
-    4. [Good practice](#Commit_messages_good_practice)
-8. [Comparing versions](#Comparing_versions)
-    1. [The problem](#Comparing_versions_the_problem)
-    2. [The solution](#Comparing_versions_the_solution)
-    3. [How to do it](#Comparing_versions_how_to_do_it)
-    4. [Good practice](#Comparing_versions_good_practice)
-9. [Branches](#Branches)
-    1. [The problem](#Branches_the_problem)
-    2. [The solution](#Branches_the_solution)
-    3. [How to do it](#Branches_how_to_do_it)
-    4. [Good practice](#Branches_good_practice)
+1. [Summary](#summary)
+2. [How version control is helpful](#how-version-control-is-helpful)
+3. [Version control: what it is and how it can be used to manage an evolving project](#version-control-what-it-is-and-how-it-can-be-used-to-manage-an-evolving-project)
+    1. [What it is](#what-it-is)
+    2. [The basic workflow](#the-basic-workflow)
+    3. [Other facilities offered by version control](#other-facilities-offered-by-version-control)
+4. [Why should you use version control?](#why-should-you-use-version-control)
+5. [Getting Started](#getting-started)
+6. [Commits](#commits)
+    1. [The problem](#the-problem)
+    2. [The solution](#the-solution)
+    3. [How to do it](#how-to-do-it)
+        1. [Retrieving past versions](#retrieving-past-versions)
+    4. [Good practice](#good-practice)
+7. [Commit messages](#commit-messages)
+    1. [The problem](#the-problem-2)
+    2. [The solution](#the-solution-2)
+    3. [How to do it](#how-to-do-it-2)
+    4. [Good practice](#good-practice-2)
+8. [Comparing versions](#comparing-versions)
+    1. [The problem](#the-problem-3)
+    2. [The solution](#the-solution-3)
+    3. [How to do it](#how-to-do-it-3)
+    4. [Good practice](#good-practice-3)
+9. [Branches](#branches)
+    1. [The problem](#the-problem-4)
+    2. [The solution](#the-solution-4)
+    3. [How to do it](#how-to-do-it-4)
+    4. [Good practice](#good-practice-4)
 10. [Merging](#merging)
-    1. [The problem](#Merging_the_problem)
-    2. [The solution](#Merging_the_solution)
-    3. [How to do it](#Merging_how_to_do_it)
-    4. [Good practice](#Merging_good_practice)  
-11. [Merge Conflicts](#merge_conflicts)
-    1. [The problem](#Merge_conflicts_the_problem)
-    2. [The solution](#Merge_conflicts_the_solution)
-    3. [How to do it](#Merge_conflicts_how_to_do_it)
-    4. [Good practice](#Merge_conflicts_good_practice)
-12. [GitHub](#GitHub)
-    1. [The problem](#GitHub_the_problem)
-    2. [The solution](#GitHub_the_solution)
-    3. [How to do it](#GitHub_how_to_do_it)
-        1. [Pull requests](#GitHub_how_to_do_it_pull_requests)
-    4. [Good practice](#GitHub_good_practice)
-13. [Summary of key Git commands](#Summary_of_key_Git_commands)
-14. [Checklists](#Checklists)
-    1. [Make use of Git](#Make_use_of_Git)
-    2. [Put your project on GitHub](#Put_your_project_on_GitHub)
-    3. [Contribute to someone else's project](#Contribute_to_someone_elses_project)
-15. [What to learn next](#What_to_learn_next)
-16. [Further reading](#further_reading)
-17. [Definitions/glossary](#Glossary)
-18. [Bibliography](#Bibliography)
+    1. [The problem](#the-problem-5)
+    2. [The solution](#the-solution-5)
+    3. [How to do it](#how-to-do-it-5)
+    4. [Good practice](#good-practice-5)
+11. [Merge Conflicts](#merge-conflicts)
+    1. [The problem](#the-problem-6)
+    2. [The solution](#the-solution-6)
+    3. [How to do it](#how-to-do-it-6)
+    4. [Good practice](#good-practice-6)
+12. [GitHub](#github)
+    1. [The problem](#the-problem-7)
+    2. [The solution](#the-solution-7)
+    3. [How to do it](#how-to-do-it-7)
+        1. [Pull requests](#pull-requests)
+    4. [Good practice](#good-practice-7)
+13. [Summary of key Git commands](#summary-of-key-git-commands)
+14. [Checklists](#checklists)
+    1. [Make use of Git](#make-use-of-git)
+    2. [Put your project on GitHub](#put-your-project-on-github)
+    3. [Contribute to someone else's project](#contribute-to-someone-elses-project)
+15. [What to learn next](#what-to-learn-next)
+16. [Further reading](#further-reading)
+17. [Definitions/glossary](#definitions-glossary)
+18. [Bibliography](#bibliography)
 
-<a name="Summary"></a>
 ## Summary
 
 Version control keeps track of different versions of a project and allows past versions to be accessed easily. It also allows different versions of a project to be merged with minimal input from the user. There are numerous tools available for version control such as Mercurial and SVN. The best know one is Git (and its web-based version, GitHub, which aids collaboration between researchers) which the instructions given in this chapter will be geared towards. There are a large number of detailed tutorials available online discussing the features and mechanics of how to use such systems (see the "[Further reading](#further_reading)" section at the end of the chapter.) This chapter aims to cover the general principles underpinning all version control systems, and best practice which applies for using all such systems.
 
-<a name="How_version_control_is_helpful"></a>
 ## How version control is helpful
 
 Keeping past versions of a project stored and accessible makes it possible to track its entire evolution, making the outputs far more reproducible. Version control software does this in a neat and powerful way, and it often saves researchers a great deal of time on reproducing lost code or analysis. Further, version control gives researchers more freedom to try things out and experiment. It does this by eliminating the risk of subsequent changes irrevocably 'breaking' the code as previous working versions will remain accessible regardless of how complex or how many changes are made.
 
 Another benefit of version control is that it makes collaboration easier, safer, and allows what changes have been made, when, why, and by who to be tracked. It does this by allowing different versions of a project (either two versions written by the same person, or versions from many people) to be worked on separately. It also has facilities to automatically compare and combine versions of a project, tasks which are often both fiddly and time-consuming when done manually.
 
-<a name="what_version_control_is_and_how_it_can_be_used"></a>
 ## Version control: what it is and how it can be used to manage an evolving project
 
-<a name="what_it_is"></a>
 ### What it is
 
 What is “version control”, and why should you care? Version control is a system that records changes to a file or set of files over time so that you can recall specific versions later. It is typically applied to managing changes in code, though in reality you can do this with nearly any type of file on a computer.
 
-<a name="The_basic_workflow"></a>
 ### The basic workflow
 
 The typical procedure for using version control is as follows:
@@ -100,7 +95,6 @@ Keep doing work and making more and more commits. You can think of commits as ch
 
 Every time you make a commit you can tag it with a commit message explaining what this snapshot of your project is doing. This makes it very easy to find what you're looking for when you need to go back to a past version.
 
-<a name="branches_overview"></a>
 ### Other facilities offered by version control
 
 So you have your project and you want to add new or something or try something out. With version control you can make a branch to do this work on. Any work you do on your branch won't be present on your main project (referred to as your master branch) so it remains nice and safe and you can continue to work on it. Once you're happy with your New Thing you can 'merge' your branch back into your master copy.
@@ -117,7 +111,6 @@ If you want you can even have branches off of branches (and branches off of thos
 
 No matter how many branches you have you can access past commits you made on any of them.
 
-<a name="Why_should_you_use_version_control"></a>
 ## Why should you use version control?
 
 People working on data science may have a large array of files (code, data, figures, notes) that they update but want to keep past versions for reference. This process is often informal and haphazard, where multiple revisions of papers, code, and datasets are saved as duplicate copies with uninformative file names (e.g. my_code.py my_code_2.py my_code_2a.py, my_code_2b.py). As authors receive new data and feedback from peers and collaborators, maintaining those versions and merging changes can result in an unmanageable proliferation of files. It is also incredibly error prone. It is easy to forget what different files contain, or to copy over files you don’t mean to. This leads to a great deal of time wasted on figuring out what files contain and reproducing accidently overwritten files.
@@ -130,7 +123,6 @@ A version control system stores all your changes neatly away so while it is stil
 
 Finally version control is invaluable for collaborative projects where different people work on the same code simultaneously. It allows the changes made by different people to be tracked, and can automatically combine people's work via merging saving a great deal of painstaking effort to do so manually. Moreover, version control hosting websites, such as GitHub, provide way to communicate in a more structured way, such as in code reviews, about commits and about issues.
 
-<a name="Getting_started"></a>
 ## Getting Started
 
 This is important to know, but it isn't that exciting. Instructions for installing Git on linux, windows and mac machines are available [here](https://Git-scm.com/book/en/v2/Getting-Started-Installing-Git). Once instillation is complete, to start using version control for your project you just go into the directory that contains all of your files (subdirectories will be included) and run
@@ -160,20 +152,16 @@ git commit
 
 We'll talk in more detail about these commands [later](#adding), but for now just know if you run them then congratulations, you have finished setting up you repository!
 
-<a name="Commits"></a>
 ## Commits
 
-<a name="Commits_the_problem"></a>
 ### The problem
 
 When working on a project you will make numerous changes to your files as you progress. Sometimes you may need to undo changes, take another look at past versions, or compare versions. Saving each version individually (version_1.py, version_2.py etc) is messy and quickly becomes impractical.
 
-<a name="Commits_the_solution"></a>
 ### The solution
 
 By making commits you can save versions of your code and switch between them/compare them easily without cluttering up your directory. Commits serve as checkpoints where individual files or an entire project can be safely reverted to when necessary.
 
-<a name="adding"></a>
 ### How to do it
 
 When you've made a series of changes and you want to commit them you fist add these changes to your staging area using `git add`. You can add all your changes using
@@ -210,7 +198,6 @@ git log
 
 In this log you'll see that each commit is automatically tagged with a unique string of numbers and letters called a SHA which you can use to access and compare them.
 
-<a name="Retrieving_past_versions"></a>
 #### Retrieving past versions
 
 To cancel your latest commit run
@@ -230,7 +217,6 @@ git checkout SHA_of_the_version
  git checkout SHA_of_the_version -- your_file_name
  ```
 
-<a name="Commits_good_practice"></a>
 ### Good practice for commits
 
 Commits should be 'atomic' i.e **they should do one simple thing and they should do it completely**, e.g. adding a new function or renaming a variable. If a lot of different changes to your project are all committed together then if something goes wrong it can be hard to unpick what in this set of changes if causing the problem, and undoing the whole commit may throw away valid and useful work along with the bug. That said **you don't necessarily need to do per-file commits**. For example if I add a figure to this chapter here, let's choose something to catch the attention of someone skimming through:
@@ -248,22 +234,18 @@ To aid in making atomic commits it's good practice to **specify the files to be 
 
 Finally, **don't commit anything that can be regenerated from other things that were committed unless it is something  that would take hours to regenerate**. Generated files just clutter up your repository and may contain features such as timestamps that can cause annoying merge conflicts (see [below](#merge_conflicts)). On a similar note you should not commit configuration files, specifically configuration files that might change from environment to environment. You can instruct Git to ignore certain files by creating a file called `.Gitignore` and including their names in it.
 
-<a name="commit_messages"></a>
 ## Commit messages
 
-<a name="Commit_messages_the_problem"></a>
 ### The problem
 
 As you work on you project you will make more and more commits. Without any other information it can be hard to remember which version of your project is in which. Storing past versions is useless if you can't understand them, and figuring out what they contain by inspecting the code is frustrating and takes valuable time.  
 
-<a name="Commit_messages_the_solution"></a>
 ### The solution
 
 When you commit you have the chance to write a commit message describing what the commit is and what it does, and you should always, *always,* **_always_** do so.  A commit message gets attached to the commit so if you look back at it (e.g via `git log`) it will show up. Creating insightful and descriptive commit messages is one of the best things you can do to get the most out of version control. It lets people (and your future self when you've long since forgotten what you were doing and why) quickly understand what changes a commit contains without having to carefully read code and waste time figuring it out. Good commit messages improve your code quality by drastically reducing its WTF/min ratio:
 
 ![wtf_per_min](../figures/wtf_per_min.jpg)
 
-<a name="Commit_messages_how_to_do_it"></a>
 ### How to do it
 
 When you commit via
@@ -278,7 +260,6 @@ notice that a field appears (either within the terminal or in a text editor) whe
 git config --global core.editor "your_preferred_editor"
 ```
 
-<a name="Commit_messages_good_practice"></a>
 ### Good practice for commit messages
 
 The number one rule is: **make it meaningful**. A commit message like "Fixed a bug" leaves it entirely up to the person  looking at the commit (again, this person may very well be you a few months in the future when you've forgotten what you were doing) to waste time figuring out what the bug was, what changes you actually made, and how they fixed it. As such a good commit message should **explain what you did, why you did it, and what is impacted by the change**. As with comments you should **describe what the code is doing rather than the code itself** e.g. it is not obvious what "Change N_sim to 10" actually does, but "Change number of simulations run by the program to 10" is clear.
@@ -308,22 +289,18 @@ Further paragraphs come after blank lines.
     between, but conventions vary here
 ```
 
-<a name="Comparing_versions"></a>
 ## Comparing versions
 
-<a name="Comparing_versions_the_problem"></a>
 ### The problem
 
 At some point it is likely you will need/want to compare versions of a project, for example to see what version was used to generate a certain result.
 
-<a name="Comparing_versions_the_solution"></a>
 ### The solution
 
 In short: `git diff`.
 
 Diffing is a function that takes two input data sets and outputs the changes between them. `git diff` is a multi-use Git command that when executed runs a diff function on Git data sources. These data sources can be commits, branches, files and more.
 
-<a name="Comparing_versions_how_to_do_it"></a>
 ### How to do it
 
 By default `git diff` will show you any uncommitted changes since the last commit. If you want to compare two specific things the syntax is
@@ -344,20 +321,16 @@ Or if you wanted to compare two branches it would be
 git diff branch_name other_branch_name
 ```
 
-<a name="Comparing_versions_good_practice"></a>
 ### Good practice for comparing versions
 
 **Use it**. With a little familiarity `git diff` becomes an extremely powerful tool you can use to track what files have changed and exactly what those changes are. This is extremely valuable for unpicking bugs and comparing work done by different people. Be careful to **understand what exactly is being compared** and where possible **only compare the relevant files** for what you're interested in to avoid large amounts of extraneous information.
 
-<a name="Branches"></a>
 ## Branches
 
-<a name="Branches_the_problem"></a>
 ### The problem
 
 If you add a new feature to your project you run the risk of accidentally breaking your working code as you make changes to it. This would be very bad for active users of your project, even if the only active user is you. Also version control systems are regularly used for collaboration. If everyone starts programming on top of the master branch, it will cause a lot of confusion. Some people may write faulty/buggy code or simply the kind of code/feature others may not want in the project. There needs to be a way allow new work to be done on a project whilst protecting work that has already been done.
 
-<a name="Branches_the_solution"></a>
 ### The solution
 
 Branches. At the start of this chapter an [overview](#branches_overview) was given of the concept of branches, but let's recap. You have a project, and you make commits on it. By default you have one branch, called 'master'. Making a branch essentially makes a copy of your code which you can work on and continue to make commits to. Meanwhile your master branch is untouched by these changes, and you can continue to make commits on it too. Once you're happy with whatever you were working on on a branch you can merge it into your master branch (or indeed any other branch). Merging will be covered in the [next section](#merging). If your work on a branch doesn't work out you can delete or abandon it (e.g. Feature B in the diagram below) rather than spending time unpicking your changes if you were doing all your work on the master copy. You can have as many branches off of branches as you desire (e.g. Feature A-1).
@@ -366,7 +339,6 @@ Using branches keeps working code safe, particularly in collaborations. Each con
 
 ![sub_branch](../figures/sub_branch.png)
 
-<a name="Branches_how_to_do_it"></a>
 ### How to do it
 
 You can create a branch and switch to it using:
@@ -390,25 +362,20 @@ If you decide to get rid of a branch you can delete it with
 git branch -D name_of_the_branch
 ```
 
-<a name="Branches_good_practice"></a>
 ### Good practice for branches
 
 Branches should be used to **keep the master branch clean** i.e. master should only contain work which is complete and tested and so rightfully belongs in the master version of the project. Similarly you should try to keep individual branches as clean as possible by **only adding one new feature per branch**, because if you are working on several features some may be finished and ready to merge into master while others are still under development. Keeping your branches clean means only making changes related to the feature on the feature's branch. Give your branches **sensible names**, "new_feature" is all well and good until you start developing a newer feature on another branch.
 
-<a name="merging"></a>
 ## Merging
 
-<a name="Merging_the_problem"></a>
 ### The problem
 
 Once you've finished up some work on a branch you need to integrate it to your main project (or any other branch).
 
-<a name="Merging_the_solution"></a>
 ### The solution
 
 Merge the branch with your work on into your target branch. You can also use merging to combine work that other people have done with your own and vice versa.
 
-<a name="Merging_how_to_do_it"></a>
 ### How to do it
 
 To merge some branch, branch_A, into another branch, branch_B, switch to branch_A via `git checkout branch_A` and merge it into branch_B by
@@ -427,15 +394,12 @@ or
 error: Entry 'your_file_name' would be overwritten by merge. Cannot merge. (Changes in staging area)
 ```
 
-<a name="Merging_good_practice"></a>
 ### Good practice for merging
 
 First and foremost your **master branch should always be stable**, only merge work that is finished and tested into it. If your project is collaborative then it's a good idea to **merge changes that others make into you own work frequently**. If you don't it's very easy for merge conflicts to arise (next section). Similarly, share your own changes with your collaborators often.
 
-<a name="merge_conflicts"></a>
 ## Merge conflicts
 
-<a name="Merge_conflicts_the_problem"></a>
 ### The problem
 
 When changes to made to the same file on different branches sometimes those changes may be incompatible. This most commonly occurs in collaborative projects, but it happens in solo projects too. Let's say there's a project and it contains a file with this line of code:
@@ -458,7 +422,6 @@ print('Hello World')
 
 They continue doing work on their respective branches and eventually decide to merge. Their version control software then goes through and combines their changes into a single version of the file, *but* when it gets to the hello world statement it doesn't know which version to use. This is a merge conflict: incompatible changes have been made to the same file.
 
-<a name="Merge_conflicts_the_solution"></a>
 ### The solution
 
 When a merge conflict arises it will be flagged during the merge process. Within the files with conflicts the incompatible changes will be marked so you can fix them:
@@ -476,7 +439,6 @@ print('Hello World')
 
 '>>>>>>>': Indicates the end of the lines that had a merge conflict.
 
-<a name="Merge_conflicts_how_to_do_it"></a>
 ### How to do it
 
 You resolve a conflict by editing the file to manually merge the parts of the file that Git had trouble merging. This may mean discarding either your changes or someone else's or doing a mix of the two. You will also need to delete the '<<<<<<<', '=======', and '>>>>>>>' in the file. So in this project the users may decide in favour of one `hello world` over another, or they may decide to replace the conflict with
@@ -492,7 +454,6 @@ If you find there are particularly nasty conflicts and you want to abort the mer
 git merge --abort
 ```
 
-<a name="Merge_conflicts_good_practice"></a>
 ### Good practice for resolving merge conflicts
 
 Before you start trying to resolve conflicts **make sure you fully understand the changes and how they are incompatible**. If you don't you risk making things more tangled. Once you do and you go about fixing the problem **be careful, but don't be afraid**; the whole point of version control is your past versions are all safe. Nevertheless merge conflicts can be intimidating to resolve, especially if you are merging branches that diverged a great many commits ago which may now have many incompatibilities. This is why it is good practice to **merge other's changes into your work frequently**.
@@ -511,15 +472,12 @@ git mergetool
 
 Fundamentally the best way to deal with merge conflicts is to, so far as is possible, **ensure they don't happen in the first place**. You can improve your odds on this by **keeping branches clean and focused on a single issue, and involving as few files as possible**. Before merging make sure you know what's in both branches, and if you are not the only one that has worked on the branches then **keep the lines of communication open** so you are all aware of what the others are doing.
 
-<a name="GitHub"></a>
 ## GitHub
 
-<a name="GitHub_the_problem"></a>
 ### The problem
 
 When multiple people work on the same project (which is becoming more and more common as research becomes increasingly collaborative) it becomes difficult to keep track of what changes have been made and by who. It is also often difficult and time-consuming to manually incorporate the different participant's work into a whole even if all of their changes are compatible.  
 
-<a name="GitHub_the_solution"></a>
 ### The solution
 
 Hosting the project on a distributed version control system such as GitHub. Collaborators can then clone the project and work on that copy making commits, branches, etc without impacting the original. Collaborators can then *push* their work to each other, and *pull* other's work into their own copy. In this way it is easy to keep everyone up to date and to track what has been done and by who. GitHub also has numerous other handy features such as the ability to raise and assign issues, discuss the project via comments, and review each other's changes.
@@ -529,7 +487,6 @@ Making the entire project and its history available online in this was also has 
 1. Other researchers can re-use the work more easily. Rather than writing their own code to do what has already been written they can just use the original, which saves time. This also benefits the project's original authors as other researchers are much more likely to build on the work (and cite it) if a great deal of the work has already been done.   
 2. The research will be much more reproducible if the entire history of the project can be tracked. This enables results to be verified more easily, which benefits science.
 
-<a name="GitHub_how_to_do_it"></a>
 ### How to do it
 
 There are a number of GitHub tutorials available such as [this one](https://guides.GitHub.com/activities/hello-world/), or if you prefer you can follow along here.
@@ -561,7 +518,6 @@ git push -u origin master
 
 Naturally the exact same procedure applies to you if you want to clone someone else's repository.
 
-<a name="GitHub_how_to_do_it_pull_requests"></a>
 #### Pull requests
 
 So everyone's got a copy of the code and they're merrily working away on it, how do collaborators share their work? Pull requests. A pull request is a request for a person to *pull* someone else's changes into their version on the project. Say person A has made changes they want to share with person B. On GitHub Person A needs to go to person B's copy of the project and click the "New pull request" button. From there they can indicate which of their branches they would like person B to pull changes from, and which branch they want the changes pulled to. If person B accepts then person A's changes will be merged into their repository by GitHub. They can discuss the request in comments, and make further commits to the request before it is accepted if necessary.
@@ -576,7 +532,6 @@ git pull origin master
 
 It is also possible to make pull requests via the command line. A guide on how to do so is available [here](https://Git-scm.com/docs/Git-request-pull).
 
-<a name="GitHub_good_practice"></a>
 ### Good practice for using GitHub
 
 In your GitHub repository you should **include a license** to allow others to re-use your work legally. GitHub makes this very easy, simply click the "Create new file" button, name it "License.md" and a drop down menu will appear offering you a selection to choose from. The legalese can seem intimidating however [this](https://choosealicense.com/) website offers a very simple mechanism to help you pick the best license for your project.
@@ -600,7 +555,6 @@ You can also **make use of one of GitHub's major features- issues**. Anyone can 
 
 In pull requests you should **clearly explain what the changes you've made are and why you made them**. If your changes address and issue that has been raised reference it directly. If your request fixes and issue and you include "will fix #the_issue_number >" in the pull request, if the pull request is merged it will automatically close the referenced issue, keeping the issue queue nice and clean! This also works for using commit messages to close issues too.
 
-<a name="Summary_of_key_Git_commands"></a>
 ## Summary of key Git commands
 
 | Command                       | Use                                                                      |
@@ -623,10 +577,8 @@ In pull requests you should **clearly explain what the changes you've made are a
 | git diff                      | Output difference between working directory and most recent commit       |
 | git diff thing_a thing_b      | Output difference between two things e.g. commits, branches              |                     
 
-<a name="Checklists"></a>
 ## Checklists
 
-<a name="Make_use_of_Git"></a>
 ### Make use of Git
 - [ ] Make your project version controlled by initialising a Git repository in its directory using `git init`
 - [ ] Add and commit all your files to the repository using `git add .` then `git commit`
@@ -643,7 +595,6 @@ In pull requests you should **clearly explain what the changes you've made are a
   - [ ] Merge other's changes into your work frequently
   - [ ] When dealing with merge conflicts make sure you fully understand both versions before trying to resolve them
 
-<a name="Put_your_project_on_GitHub"></a>
 ### Put your project on GitHub
 - [ ] Create a GitHub account
 - [ ] Create a repository on GitHub with the same name as your project
@@ -656,7 +607,6 @@ In pull requests you should **clearly explain what the changes you've made are a
 - [ ] Set expectations for how collaborators are expected to behave via a code of conduct and or ways of working document
 - [ ] Use issues to track and discuss modifications to the project
 
-<a name="Contribute_to_someone_elses_project"></a>
 ### Contribute to someone else's project
 - [ ] Clone their project's repository from GitHub `git clone repository_url`
 - [ ] Make and commit changes
@@ -665,19 +615,16 @@ In pull requests you should **clearly explain what the changes you've made are a
 - [ ] Make pull requests on GitHub to share your work
   - [ ] Clearly explain the changes you've made and why in your pull request.
 
-<a name="What_to_learn_next"></a>
 ## What to learn next
 
 Look into best practice for writing good quality code (good naming conventions, informative comments, modular code structure etc). Many such skills are either also applicable for using version control well, e.g. for writing good commit messages, or make using version control easier by keeping changes neat and localised.
 
-<a name="further_reading"></a>
 ## Further reading
 
 - A free and very in depth book on Gits myriad of features can be found [here](https://Git-scm.com/book/en/v2)
 - A useful Git cheat sheet can be found [here](https://services.GitHub.com/on-demand/downloads/GitHub-Git-cheat-sheet.pdf)
 - Interactive tutorials for familiarising yourself with GitHub can be found at [https://lab.github.com/](https://lab.github.com/).
 
-<a name="Glossary"></a>
 ## Definitions/glossary
 
 **Add:** Command used to add files to the staging area. Allows the user to specify which files or directories to include in the next commit.
@@ -716,7 +663,6 @@ Look into best practice for writing good quality code (good naming conventions, 
 
 **Staged:** Changes that will be included in the next commit.
 
-<a name="Bibliography"></a>
 ## Bibliography
 
 - [1.](https://git-scm.com/book/en/v2/Getting-Started-About-Version-Controls) **Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License**


### PR DESCRIPTION
### Summary
GitHub's Markdown processing automatically creates HTML anchors for each heading, regardless of level.  The auto-generated anchor text is
*  the text of the heading
*  with special characters removed
*  with spaces replaced with hyphens
*  and all lowercase.

This PR switches the Tables of Contents to use these auto-generated anchors and removes the manually inserted ones.

### Acknowledging contributors
By submitting this pull request I confirm that:
- [ ] all contributors to this pull request who wish to be included are named in [contributors.md](https://github.com/alan-turing-institute/the-turing-way/blob/master/contributors.md).
