### PR TITLE
[Ready for review] Change contributors acknowledgment in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,9 +3,9 @@ Please complete the following sections when you submit your pull request. You ar
 -->
 ### Summary
 
-<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent -->
+<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent. For example: "Fixes #58", or "Addresses (but does not close) #238". -->
 
-Fixes #<NUM> <!-- (e.g. Fixes #58.) -->
+Fixes #<NUM>
 
 *Lorem ipsum dolor sit amet, consectetur adipiscing.*
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,9 @@
 <!--
-Please complete the following sections when you submit your pull request.
-You are encouraged to keep this top level comment box updated as you
-develop and respond to reviews.
-Note that text within html comment tags will not be rendered.
+Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
 -->
 ### Summary
 
-<!-- Describe the problem you're trying to fix in this pull request. Please
-reference any related issue and use fixes/close to automatically close them,
-if pertinent -->
+<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent -->
 
 Fixes #<NUM> <!-- (e.g. Fixes #58.) -->
 
@@ -24,19 +19,15 @@ Fixes #<NUM> <!-- (e.g. Fixes #58.) -->
 
 ### What should a reviewer concentrate their feedback on?
 
-<!-- This section is particularly useful if you have a pull request that is
-still in development. You can guide the reviews to focus on the parts that are
-ready for their comments.
-We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
+<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
 
 - [ ] *Lorem ipsum dolor sit amet, consectetur adipiscing.*
-- [ ] *Lorem ipsum dolor sit amet, consectetur adipiscing.*
+- [ ] Everything looks ok?
 
 
 ### Acknowledging contributors
 
-<!-- Please select the box when confirmed -->
+<!-- Please select the correct box -->
 
-By submitting this pull request I confirm that:
-
-- [ ] all contributors to this pull request who wish to be included are named in [contributors.md](https://github.com/alan-turing-institute/the-turing-way/blob/master/contributors.md).
+- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file.
+- [ ] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->


### PR DESCRIPTION
* Adjust acknowledging contributors section to point to table of contributors instead of contributors.md file.
* Put html comments all on the same line. GitHub will wrap them nicely 😄

<!--
Please complete the following sections when you submit your pull request.
You are encouraged to keep this top level comment box updated as you
develop and respond to reviews.
Note that text within html comment tags will not be rendered.
-->
### Summary

<!-- Describe the problem you're trying to fix in this pull request. Please
reference any related issue and use fixes/close to automatically close them,
if pertinent -->

Doesn't close an open issue.

Our PR template doesn't make sense now that we use the all contributors bot rather than asking people to manually add themselves to the contributors.md file. Hopefully this fixes it!

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* Adjust acknowledging contributors section to point to table of contributors instead of contributors.md file.
* Put html comments all on the same line. GitHub will wrap them nicely 😄


### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is
still in development. You can guide the reviews to focus on the parts that are
ready for their comments.
We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [ ] Does this make sense?


### Acknowledging contributors

<!-- Please select the box when confirmed -->

By submitting this pull request I confirm that:

- [x] all contributors to this pull request who wish to be included are named in [contributors.md](https://github.com/alan-turing-institute/the-turing-way/blob/master/contributors.md).
