### PR TITLE
feat: Add basic glossary placeholder

### DIFF
--- a/book/content/glossary/glossary.md
+++ b/book/content/glossary/glossary.md
@@ -1,0 +1,37 @@
+# Glossary
+
+#### Binder
+
+A web-based service which allows users to upload and share fully-functioning versions of their projects in an environment they define.
+
+#### Computational environment
+
+Features of a computer which can impact the behaviour of work done on it, such as its operating system, what software it has installed, and what versions of software packages are installed.
+
+#### Conda
+
+A commonly used package management system.
+
+#### Container
+
+Lightweight files that can encapsulate and entire computational environment including its operating system, customised settings, software and files.
+
+#### Dockerfile
+
+A file used for creating Docker images
+
+#### Image
+
+Files used for generating containers.
+
+#### Package management system
+
+A tool for installing, managing, and uninstalling software packages including specific versions.
+
+#### Virtual machine
+
+A simulated computer that can encapsulate and entire computational environment including its operating system, customised settings, software and files.
+
+#### YAML
+
+A human readable/writable markup language which used by many projects for configuration files.

--- a/book/website/_data/toc.yml
+++ b/book/website/_data/toc.yml
@@ -100,3 +100,5 @@
     url: risk_assessment/01/longreadriskassessment
   - title: Summary
     url: risk_assessment/02/finalsummary
+- title: Glossary
+  url: glossary/glossary


### PR DESCRIPTION
### Summary

Addresses (but does not close): #598, #616

Add a centralised glossary.

### List of changes proposed in this PR (pull-request)

* Adds a centralised glossary.
* Adds a proof-of-concept script for checking links to glossary items:
    1. We want to be able to link from the main text to glossary items.
    2. We want to know when we've used a term in the text but have forgotten to link to the glossary.

### What should a reviewer concentrate their feedback on?

- [ ] Everything looks ok?

### Acknowledging contributors

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file.