### PR TITLE
[Quick Fix] Update requirements.txt to pin Jupyter Book to v 0.5.2

### DIFF
--- a/book/website/requirements.txt
+++ b/book/website/requirements.txt
@@ -5,4 +5,4 @@ numpy
 datascience
 folium
 matplotlib
-jupyter-book
+jupyter-book==0.5.2


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent. For example: "Fixes #58", or "Addresses (but does not close) #238". -->

Doesn't fix an open issue 😭 (although I've now made #692 to implement a better fix)

Jupyterbook has updated and its ended up breaking our CI a bit. So this hot fix sets jupyter book's version to a specific release (0.5.2)

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* @alexmorley's update to `requirements.txt` that I've cherry picked from #687 

### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [ ] Everything looks ok?


### Acknowledging contributors

<!-- Please select the correct box -->

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
