### PR TITLE
Update R testing frameworks

### DIFF
--- a/book/content/testing/testing.md
+++ b/book/content/testing/testing.md
@@ -144,7 +144,8 @@ There are tools available to make writing and running tests easier, these are kn
   - pytest (recommended)
   - unittest comes with standard Python library
 - R unit-tests
-  - RUnit
+  - testthat
+  - tinytest
   - svUnit (works with SciViews GUI)
 - Fortran unit-tests:
   - funit


### PR DESCRIPTION
### Summary

<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent. For example: "Fixes #58", or "Addresses (but does not close) #238". -->
Update R testing frameworks. `testthat` is the most used framework and its development is active, `tinytest` is also active, but `Runit`'s last release is more than a year old (some packages like RcppArmadillo have rewritten their tests recently to stop using Runit).

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* Remove `Runit` from the R testing frameworks list
* Add `testthat` and `tinytest` to the R testing frameworks list

### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [ ] Everything looks ok?


### Acknowledging contributors

<!-- Please select the correct box -->

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
  - [ ] @OriolAbril