### PR TITLE
Move all-contributors badge to end

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # The Turing Way
 
-[![Build Status](https://img.shields.io/travis/alan-turing-institute/the-turing-way/master?logo=travis)](https://travis-ci.org/alan-turing-institute/the-turing-way) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-69-orange.svg)](#contributors-) <!-- ALL-CONTRIBUTORS-BADGE:END -->
+[![Build Status](https://img.shields.io/travis/alan-turing-institute/the-turing-way/master?logo=travis)](https://travis-ci.org/alan-turing-institute/the-turing-way)
 [![Read the book](https://img.shields.io/badge/read-the%20book-blue.svg)](https://the-turing-way.netlify.com)
 [![Join our tinyletter mailing list](https://img.shields.io/badge/receive-our%20newsletter%20❤%EF%B8%8F-blueviolet.svg)](https://tinyletter.com/TuringWay)
 [![Join the chat at https://gitter.im/alan-turing-institute/the-turing-way](https://img.shields.io/gitter/room/alan-turing-institute/the-turing-way?logo=gitter)](https://gitter.im/alan-turing-institute/the-turing-way)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3233853.svg)](https://doi.org/10.5281/zenodo.3233853)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3233853.svg)](https://doi.org/10.5281/zenodo.3233853) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![All Contributors](https://img.shields.io/badge/all_contributors-69-orange.svg)](#contributors-) <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 _The Turing Way_ is a lightly opinionated guide to reproducible data science.
 You can read it here: https://the-turing-way.netlify.com.


### PR DESCRIPTION
Another follow-on from #893 - this PR moves the all-contributors badge to the end of the row so that the marker for the end of the badge doesn't cause a line break between other badges.