### PR TITLE
Add demonstrations of including tables into Make chapter

### DIFF
--- a/book/content/make/make.md
+++ b/book/content/make/make.md
@@ -95,7 +95,7 @@ By using tools such as LaTeX, you can even generate a complete manuscript that
 includes freshly computed figures and results!
 This can increase the trust in the research output that you generate, it can
 make your research more accessible, and it can make collaborating easier.
-This chapter can show you how to get started:
+This chapter can show you how to get started.
 
 ## Learn Make by Example
 
@@ -736,7 +736,7 @@ can insert it into your manuscript:
 \end{table}
 ```
 
-An alternative is to make use of variables:
+An alternative is to make use of variables.
 Instead of creating a table in a separate file, you can write a table skeleton
 and populate it with variables.
 The results you compute are associated with the variables, and once your

--- a/book/content/make/make.md
+++ b/book/content/make/make.md
@@ -24,6 +24,7 @@ Recommended skill level: intermediate
   - [Makefile no. 5 (Wildcards and Path Substitution)](#makefile-no-5-wildcards-and-path-substitution)
   - [Debugging Makefiles](#debugging-makefiles)
 - [A Real Reproducible Paper using Make](#a-real-reproducible-paper-using-make)
+- [Including numerical results and tables](#including-numerical-results-and-tables)
 - [Further Reading](#further-reading)
   - [Manual](#manual)
   - [Discussions](#discussions)

--- a/book/content/make/make.md
+++ b/book/content/make/make.md
@@ -777,15 +777,23 @@ Note that this example uses Python, but you can use any language or method you
 are familiar with to print definitions like this.
 With this definition, LaTeX exchanges the table cell with `\var1mean` with the
 numeric result from the computation.
-You can capture the definitions and write them to a file with a little help of
-Make and the [tee](https://en.wikipedia.org/wiki/Tee_(command)) command that can
-write output your script prints into a file.
+You can capture the definitions and write them to a file using redirection with
+`>`.
 In this example, we write it to a file called `results_def.tex`
 
 ```
 results_def.tex: code/make_summary_stats.py
-    python code/make_summary_stats.py | tee results_def.tex'
+    python code/make_summary_stats.py > results_def.tex
 ```
+
+As an alternative to `>`, you could also redirect the results using the Unix
+[pipe](https://en.wikipedia.org/wiki/Pipeline_(Unix)) and the
+[tee](https://en.wikipedia.org/wiki/Tee_(command)) command
+(`python code/make_summary_stats.py | tee results_def.tex`).
+This will not only redirect the output of the script to a file, but also print
+them into your terminal.
+This helpful trick can help you observe whether everything works as expected
+during the execution of your script.
 
 Finally, use the `input{}` command to include the new variables in your
 manuscript and the variables in the tables:

--- a/book/content/make/make.md
+++ b/book/content/make/make.md
@@ -704,6 +704,102 @@ The published Makefile in the repository does not contain the paper, but this
 collaboration as only a single repository needed to be shared that contains 
 the code, the results, and the manuscript.
 
+## Including numerical results and tables
+
+At this point you may be thinking "That's so cool that I can now include figures
+into my manuscripts! But how exactly does this work for numerical results?"
+
+The reproducible paper linked above shows one way of doing it:
+After the results are computed, they are written out in the form of a LaTeX
+table.
+Here is how one of these tables looks like right after it was computed:
+
+```
+\begin{tabular}{lrrr|rrrr}
+Property & HypoParsr & Sniffer & Suitability & Pattern & Type & No Tie & Full\\
+\hline
+Delimiter & 87.48 & 86.82 & 65.41 & 92.61 & 88.33 & 91.38 & \textbf{94.92}\\
+Quotechar & 82.90 & 92.36 & 44.60 & 95.23 & 90.10 & 93.80 & \textbf{97.36}\\
+Escapechar & 87.96 & 94.37 & 74.85 & 97.95 & 96.26 & 95.44 & \textbf{99.25}\\
+Overall & 80.60 & 85.45 & 38.19 & 90.99 & 83.61 & 90.61 & \textbf{93.75}\\
+\hline
+```
+
+To include this table into your manuscript, you can use LaTeX's `\input{}`
+function. If the file with the table is called `mytable.tex`, this command
+can insert it into your manuscript:
+
+```
+\begin{table}
+\input{mytable}
+\end{table}
+```
+
+An alternative is to make use of variables:
+Instead of creating a table in a separate file, you can write a table skeleton
+and populate it with variables.
+The results you compute are associated with the variables, and once your
+manuscript is compiled, variables are exchanged for real numerical results.
+Here is how such a table looks like in your manuscript:
+
+```
+\begin{table}
+    \begin{tabular*}{ccc}
+        \textbf{Variable} & \textbf{Mean}   & \textbf{Std. deviation} \
+        \hline
+        Variable 1        & \var1mean       & \var1std                \
+        Variable 2        & \var2mean       & \var2std                \
+    \end{tabular*}
+\end{table}
+```
+
+Ỳou may notice that `\var1mean` is no standard LaTeX command: It is a variable
+that you can define yourself!
+How is this done?
+Have your script print the results you compute within a `\newcommand{}{}`
+definition into a file, for example like this (simplified Python example):
+
+```
+# this loops to data vectors of two variables (data1, data2), compute the
+# mean and standard deviation, and print the results together with the
+# variable name ('var1', 'var2')
+for name, data in (['var1', data1], ['var2', data2]):
+    mean = np.mean(data)
+    std = np.mean(data)
+    print('\\newcommand{\\%s }{ %f }' % (name + 'mean', mean))
+    print('\\newcommand{\\%s }{ %f }' % (name + 'std', std))
+```
+
+Let's say the mean of the first dataset is 9.2, the definition would look like
+this: `\newcommand{\var1mean}{9.2}`.
+Note that this example uses Python, but you can use any language or method you
+are familiar with to print definitions like this.
+With this definition, LaTeX exchanges the table cell with `\var1mean` with the
+numeric result from the computation.
+You can capture the definitions and write them to a file with a little help of
+Make and the [tee](https://en.wikipedia.org/wiki/Tee_(command)) command that can
+write output your script prints into a file.
+In this example, we write it to a file called `results_def.tex`
+
+```
+results_def.tex: code/make_summary_stats.py
+    python code/make_summary_stats.py | tee results_def.tex'
+```
+
+Finally, use the `input{}` command to include the new variables in your
+manuscript and the variables in the tables:
+
+```
+\begin{document}
+\input{results_def.tex}
+```
+
+The examples shown here are simplistic, but with a bit of thinking, you can
+make sure to include results into your manuscript just as they are computed.
+This helps you (no mistakes copying results to tables, yay!) and makes your
+research more accessible and reproducible.
+
+
 ## Further Reading
 
 ### Manual
@@ -746,6 +842,10 @@ but can add further information and examples.
 - [Automatic Data-analysis 
   Pipelines](http://stat545.com/automation04_make-activity.html). A similar 
   tutorial that uses R for the analysis.
+
+- [Writing a reproducible Paper](http://handbook.datalad.org/en/latest/usecases/reproducible-paper.html#automation-with-existing-tools).
+  A similar tutorial with Python using variables to populate tables in the
+  manuscript.
 
 ### Tools
 

--- a/book/content/make/make.md
+++ b/book/content/make/make.md
@@ -715,7 +715,7 @@ After the results are computed, they are written out in the form of a LaTeX
 table.
 Here is how one of these tables looks like right after it was computed:
 
-```
+```latex
 \begin{tabular}{lrrr|rrrr}
 Property & HypoParsr & Sniffer & Suitability & Pattern & Type & No Tie & Full\\
 \hline
@@ -730,7 +730,7 @@ To include this table into your manuscript, you can use LaTeX's `\input{}`
 function. If the file with the table is called `mytable.tex`, this command
 can insert it into your manuscript:
 
-```
+```latex
 \begin{table}
 \input{mytable}
 \end{table}
@@ -743,7 +743,7 @@ The results you compute are associated with the variables, and once your
 manuscript is compiled, variables are exchanged for real numerical results.
 Here is how such a table looks like in your manuscript:
 
-```
+```latex
 \begin{table}
     \begin{tabular*}{ccc}
         \textbf{Variable} & \textbf{Mean}   & \textbf{Std. deviation} \
@@ -760,7 +760,7 @@ How is this done?
 Have your script print the results you compute within a `\newcommand{}{}`
 definition into a file, for example like this (simplified Python example):
 
-```
+```python
 # this loops to data vectors of two variables (data1, data2), compute the
 # mean and standard deviation, and print the results together with the
 # variable name ('var1', 'var2')
@@ -781,7 +781,7 @@ You can capture the definitions and write them to a file using redirection with
 `>`.
 In this example, we write it to a file called `results_def.tex`
 
-```
+```makefile
 results_def.tex: code/make_summary_stats.py
     python code/make_summary_stats.py > results_def.tex
 ```
@@ -798,7 +798,7 @@ during the execution of your script.
 Finally, use the `input{}` command to include the new variables in your
 manuscript and the variables in the tables:
 
-```
+```latex
 \begin{document}
 \input{results_def.tex}
 ```

--- a/book/content/make/make.md
+++ b/book/content/make/make.md
@@ -724,6 +724,7 @@ Quotechar & 82.90 & 92.36 & 44.60 & 95.23 & 90.10 & 93.80 & \textbf{97.36}\\
 Escapechar & 87.96 & 94.37 & 74.85 & 97.95 & 96.26 & 95.44 & \textbf{99.25}\\
 Overall & 80.60 & 85.45 & 38.19 & 90.99 & 83.61 & 90.61 & \textbf{93.75}\\
 \hline
+\end{tabular}
 ```
 
 To include this table into your manuscript, you can use LaTeX's `\input{}`
@@ -783,7 +784,7 @@ In this example, we write it to a file called `results_def.tex`
 
 ```makefile
 results_def.tex: code/make_summary_stats.py
-    python code/make_summary_stats.py > results_def.tex
+	python code/make_summary_stats.py > results_def.tex
 ```
 
 As an alternative to `>`, you could also redirect the results using the Unix

--- a/book/content/make/make.md
+++ b/book/content/make/make.md
@@ -72,6 +72,7 @@ There are several reasons why Make is a good tool to use for reproducibility:
 
 1. Make is easy to learn
 1. Make is available on many platforms
+1. Make is flexible
 1. Many people are already familiar with Make
 1. Makefiles reduce cognitive load because as long as the common Make targets 
    ``all`` and ``clean`` are present (explained below), you can be up and 
@@ -85,6 +86,15 @@ There are several reasons why Make is a good tool to use for reproducibility:
 1. Because Makefiles are text files they are easy to share and keep in version 
    control.
 1. Using Make doesn't exclude using other tools such as Travis and Docker.
+
+With a clever Makefile, you can share a complete analysis (code, data, and
+computational workflows) and let collaborators or the readers of your paper
+recompute your results.
+By using tools such as LaTeX, you can even generate a complete manuscript that
+includes freshly computed figures and results!
+This can increase the trust in the research output that you generate, it can
+make your research more accessible, and it can make collaborating easier.
+This chapter can show you how to get started:
 
 ## Learn Make by Example
 


### PR DESCRIPTION
# Summary

At the moment, the chapter on Make  does not demonstrate how to actually include tables into a manuscript, and the way it is done in the linked GitHub repo can be hard to understand.
In this PR, I try to demonstrate how the example paper does it, and also include an alternative way of doing it with LaTeX variables. For both approaches, I have included simplified demonstrations.

Fixes #854 

### List of changes proposed in this PR (pull-request)

* Add another reason for using Make (flexibility)
* Add section "Including numerical results and tables"  just before the Further Reading of the chapter.

### What should a reviewer conc entrate their feedback on?

- [ ] Is the content understandable, is the idea/concept clearly communicated?
- [ ] Everything looks ok?


### Acknowledging contributors

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file.
- [x] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file: @adswa
