### PR TITLE
Change pages footer to link to Turing Way contributors

### DIFF
--- a/book/website/_config.yml
+++ b/book/website/_config.yml
@@ -30,8 +30,8 @@ url: https://the-turing-way.netlify.com # the base hostname & protocol for your 
 # Jupyter Book settings
 
 # Main page settings
-footer_text: This page was created by <a href="https://github.com/jupyter/jupyter-book/graphs/contributors">The
-  Jupyter Book Community</a>
+footer_text: This page was created by <a href="https://github.com/alan-turing-institute/the-turing-way#contributors">The
+  Turing Way Community</a>
 
 # Sidebar settings
 show_sidebar: true                # Show the sidebar. Only set to false if your only wish to host a single page.


### PR DESCRIPTION
### Summary

This PR updates the page footers of the book to link to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) of The Turing Way.

Fixes #929 

### List of changes proposed in this PR (pull-request)

* Instead of ponting to the jupyter-book contributors, the footer of the book's pages now points to the Turing Way contributors


### What should a reviewer concentrate their feedback on?
- [x] Everything looks ok?


### Acknowledging contributors
- [x] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file: @martinagvilas 
