### PR TITLE
Add "et cetera" as a deprecated Latinism

### DIFF
--- a/tests/no-bad-latin.py
+++ b/tests/no-bad-latin.py
@@ -70,7 +70,7 @@ def read_and_check_files(files):
 				  containing the offending line.
 	"""
     failing_files = {}
-    bad_latin = ["i.e.", "e.g.", "e.t.c.", " etc", " ie"]
+    bad_latin = ["i.e.", "e.g.", "e.t.c.", " etc", " ie", "et cetera"]
 
     for filename in files:
         with open(filename, encoding="utf8", errors="ignore") as f:


### PR DESCRIPTION
### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* Add "et cetera" to the list of bad Latin phrases checked for on CI

### Acknowledging contributors

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
