### PR TITLE
multilingual make uses cached table of contents instead

### DIFF
--- a/book/content/po/toc.yml
+++ b/book/content/po/toc.yml
@@ -1,0 +1,123 @@
+# Each entry has the following schema:
+#
+# - title: mytitle   # Title of chapter or section
+#   url: /myurl  # URL of section relative to the /content/ folder.
+#   sections:  # Contains a list of more entries that make up the chapter's sections
+#   not_numbered: true  # if the section shouldn't have a number in the sidebar
+#     (e.g. Introduction or appendices)
+#   expand_sections: true  # if you'd like the sections of this chapter to always
+#     be expanded in the sidebar.
+#   external: true  # Whether the URL is an external link or points to content in the book
+#
+# Below are some special values that trigger specific behavior:
+# - search: true  # Will provide a link to a search page
+# - divider: true  # Will insert a divider in the sidebar
+# - header: My Header  # Will insert a header with no link in the sidebar
+#
+# ==============================
+# AUTOMATICALLY GENERATED TOC FILE.
+# You should review the contents of this file, re-order items as you wish,
+# and nest chapters in sections if you wish. The ======= symbols represent
+# folder breaks.
+#
+# See the demo `toc.yml` for the right structure to follow. You can
+# generate a demo book by running `jupyter-book create mybook --demo`
+# ==============================
+
+
+
+# ===== NEW SECTION ========================================
+- title: Introduction
+  url: introduction/introduction
+- title: Reproducibility
+  url: reproducibility/reproducibility
+  sections:
+  - title: Why reproducibility is important
+    url: reproducibility/01/importantforscience
+  - title: Why you should care
+    url: reproducibility/02/whycare
+  - title: Definitions
+    url: reproducibility/03/definitions
+  - title: Resources
+    url: reproducibility/04/resources
+- title: Open Research
+  url: open_research/open_research
+  sections:
+  - title: Open data
+    url: open_research/01/opendata
+  - title: Open source software
+    url: open_research/02/opensourcesoftware
+  - title: Open hardware
+    url: open_research/03/openhardware
+  - title: Open access
+    url: open_research/04/openaccess
+  - title: Open notebooks
+    url: open_research/05/opennotebooks
+  - title: Open scholarship
+    url: open_research/06/openscholarship
+  - title: Resources
+    url: open_research/07/resources
+- title: Version Control
+  url: version_control/version_control
+- title: Collaborating on GitHub/GitLab
+  url: collaborating_github/collaborating_github
+  sections:
+  - title: README and Project Communication
+    url: collaborating_github/1/readme_communication
+  - title: Roadmapping
+    url: collaborating_github/2/roadmapping
+  - title: Getting Contributors
+    url: collaborating_github/3/getting_contributors
+  - title: Checklist and Bibliography
+    url: collaborating_github/4/checklist_bibliography
+- title: Credit for reproducible research
+  url: credit/credit
+- title: Research Data Management
+  url: rdm/rdm
+- title: Reproducible Environments
+  url: reproducible_environments/reproducible_environments
+  sections:
+  - title: Choosing a tool
+    url: reproducible_environments/01/options
+  - title: Conda
+    url: reproducible_environments/02/package-management
+  - title: YAML
+    url: reproducible_environments/03/yaml
+  - title: Binder
+    url: reproducible_environments/04/binder
+  - title: Virtual machines
+    url: reproducible_environments/05/virtual-machines
+  - title: Containers
+    url: reproducible_environments/06/containers
+  - title: Checklist
+    url: reproducible_environments/07/checklist
+  - title: Resources
+    url: reproducible_environments/08/resources
+- title: Testing
+  url: testing/testing
+- title: Reviewing
+  url: reviewing/reviewing
+  sections:
+  - title: How this will help you and why this is useful
+    url: reviewing/01/how_helpful
+  - title: Best Practice
+    url: reviewing/02/best_practice
+  - title: Typical Workflows
+    url: reviewing/03/typical_workflows
+  - title: Checklists, what to learn next and bibliography
+    url: reviewing/04/checklists_bib
+- title: Continuous Integration
+  url: continuous_integration/continuous_integration
+- title: Reproducible Research with Make
+  url: make/make
+- title: Risk Assessment
+  url: risk_assessment/risk_assessment
+  sections:
+  - title: Long Read on Risk Assessment
+    url: risk_assessment/01/longreadriskassessment
+  - title: Summary
+    url: risk_assessment/02/finalsummary
+- title: BinderHub
+  url: binderhub/binderhub
+- title: Glossary
+  url: glossary/glossary

--- a/book/website/scripts/multilingual_make.sh
+++ b/book/website/scripts/multilingual_make.sh
@@ -8,23 +8,23 @@ cd ../website
 # the translated Markdown files will be
 sed 's+content_folder_name: ../content+content_folder_name: ../content/locale/+g' _config.yml > _config-locale.yml
 # Make backup of the original table of content
-cp _data/toc.yml _data/toc.yml.bak
+cp ../content/po/toc.yml ../content/po/toc.yml.bak
 cat ../content/po/LINGUAS | while read lang;
 do
     echo ${lang}
     # Make language specific table of content
-    sed "s/url: /url: ${lang}\//g" _data/toc.yml.bak > _data/toc.yml
+    sed "s/url: /url: ${lang}\//g" ../content/po/toc.yml.bak > ../content/po/toc.yml
     # Use the locale config to build each language version of the book
-    jupyter-book build ./ --overwrite --config _config-locale.yml
+    jupyter-book build ./ --overwrite --config _config-locale.yml --toc ../content/po/toc.yml
     # Change the path to figures directory one level higher
     # This will use the figures from the English version
     # Should a translated figure exist, it will reside in a folder different
     # from the sed match here
-    find _build/${lang}/ -name *.md -exec sed -i "s+\.\./figures+../../figures+g" {} +
+    find _build/${lang}/ -name *.md -exec sed -ie "s+\.\./figures+../../figures+g" {} +
     bundle exec jekyll build
     # Remove the translated Markdown from the _build directory otherwise jekyll 
     # will build those files again
     rm -r _build/${lang}
 done
 # Restore the table of content to the oiginal version
-cp _data/toc.yml.bak _data/toc.yml
+cp ../content/po/toc.yml.bak ../content/po/toc.yml


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary
`multilingual_make.sh` uses cached table of contents instead. This is to decoupled already generated po files from updates of the source table of contents.

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
Modify source location of toc.yml in the multilingual_make script.


### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [ ] Everything looks ok?


### Acknowledging contributors

<!-- Please select the correct box -->

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
