### PR TITLE
Fixing broken link https://git-scm.com/docs/git-request-pull

### DIFF
--- a/book/content/version_control/version_control.md
+++ b/book/content/version_control/version_control.md
@@ -622,7 +622,7 @@ git pull origin master
 ```
 
 It is also possible to make pull requests via the command line.
-A guide on how to do so is available [here](https://Git-scm.com/docs/Git-request-pull).
+A guide on how to do so is available [here](https://Git-scm.com/docs/git-request-pull).
 
 ### Good practice
 


### PR DESCRIPTION

### Summary

Link for doing pull request via terminal was https://git-scm.com/docs/Git-request-pull which gave 404 and then redirected to general docs page. Changing the link to https://git-scm.com/docs/git-request-pull fixed it (small case *g*)

Fixes #<NUM>

*Fixing broken link to https://git-scm.com/docs/git-request-pull*

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* https://git-scm.com/docs/Git-request-pull changed to https://git-scm.com/docs/git-request-pull



### What should a reviewer concentrate their feedback on?

- [ ] Please test that the link works for you too


### Acknowledging contributors

<!-- Please select the correct box -->

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file.
- [x] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file: eglerean
