### PR TITLE
Fixes #1016 - remove referece to non-existent file from CONTRIBUTING.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -335,22 +335,6 @@ You can build and host the book website locally. The steps are:
    jupyter-book build .
    ```
 
-### To host the book locally
-
-1. Install [docker](https://www.docker.com/): see [Reproducible Environments](https://the-turing-way.netlify.com/reproducible_environments/reproducible_environments.html#Containers_section) for discussion of docker and containers.
-
-2. Make sure you have docker-compose installed: [compose installation instructions](https://docs.docker.com/compose/install/)
-
-Start the website locally using the following commands:
-
-   ```
-   cd book/website
-   docker-compose up
-   ```
-
-   This will install all ruby requirements and make the site available at `http://0.0.0.0:4000/introduction/introduction`.
-
-
 ## Style Guide
 
 


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

Fixes #1016 by removing dangling reference to `docker-compose.yml` in `CONTRIBUTING.md`.

### List of changes proposed in this PR (pull-request)

Just one very simple change: removes reference to `docker-compose.yml` that was removed a while ago.

### What should a reviewer concentrate their feedback on?

I think the idea of running locally is very valuable. Furthermore, I am currently unable to run the book locally on my Fedora 31 machine without `Docker` or `podman`. I would be interested in proposing an alternative Docker configuration, especially since this book advocates for using containers. I am very interested in discussing other possible solutions!

### Acknowledging contributors

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
