### PR TITLE
Added jupyter book links and corrected path for figures

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ While this formats in the same way as if the new line wasn't included, it makes 
 ## Where to start: issues
 
 Before you open a new issue, please check if any of our [open issues](https://github.com/alan-turing-institute/the-turing-way/issues) covers your idea already.
-If you open a new issue, please follow our basic guidelines laid out in our [issue template](https://github.com/alan-turing-institute/the-turing-way/blob/master/.github/ISSUE_TEMPLATE.md).
+If you open a new issue, please follow our basic guidelines laid out in our [issue template](https://github.com/alan-turing-institute/the-turing-way/tree/master/.github/ISSUE_TEMPLATE/) which are further classified into [New Chapter Template](https://github.com/alan-turing-institute/the-turing-way/tree/master/.github/ISSUE_TEMPLATE/CHAPTER_ISSUE_TEMPLATE.md) , [General](https://github.com/alan-turing-institute/the-turing-way/tree/master/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md) and [Bug Report](https://github.com/alan-turing-institute/the-turing-way/tree/master/.github/ISSUE_TEMPLATE/bug_report.md).
 The issue template will automatically be rendered in the comment section of the new issue page, so all you need to do is edit the "_Lorem ipsum_" sections.
 
 ### Issue labels

--- a/book/README.md
+++ b/book/README.md
@@ -1,12 +1,13 @@
 ## The Turing Way Book
+
 *For the main repo (where most of the issues live) please [follow this link](https://github.com/alan-turing-institute/the-turing-way).*
 
 All the text for each chapter lives inside its own folder in the `content/` directory.
-
 All figures associated to the chapters are stored in and linked from the `book/content/figures/` directory.
-Everything else is in the `website/` folder.
+Everything else is in the `website/` directory.
 
 ### Configuration
+
 - The table of contents (TOC) defines the order of chapters as they appear in the book.
 To change the TOC, please edit the `website/_data/toc.yml` file with correct information on file names and their relative locations in this repository. 
 Documentation on controlling the TOC structure can be found on the [jupyter book website](https://jupyterbook.org/customize/toc.html).
@@ -14,9 +15,11 @@ Documentation on controlling the TOC structure can be found on the [jupyter book
 Documentation on configuring book settings can be found on the [jupyter book website](https://jupyterbook.org/customize/config.html).
 
 ### Deploying
+
 The site is built automatically using these two directories. All of the requirements are specificied in `website/requirements.txt`.
 
 #### Locally (Mac / Linux Only)
+
 To install jupyter-book etc.
 ```
 cd book/website
@@ -59,6 +62,7 @@ make site && make serve
 ```
 
 #### On Netlify
+
 You'll just need the following settings:
 - Base directory: `website`
 - Build command: `make site`

--- a/book/README.md
+++ b/book/README.md
@@ -10,7 +10,8 @@ Everything else is in the `website/` folder.
 - The table of contents (TOC) defines the order of the chapters as they appear in the book.
 To change the TOC, please edit the `website/_data/toc.yml` file with correct information on the location of chapters, their corresponding file names and the relative location of the files. 
 Documentation on controlling the TOC structure can be found on the [jupyter book website](https://jupyterbook.org/customize/toc.html).
-- Same applies for more general configuration using `website/_config.yml` whose documentation can be viewed on [Configure book settings](https://jupyterbook.org/customize/config.html)
+- Same applies for more general configuration using `website/_config.yml`. 
+Documentation on configuring book settings can be found on the [jupyter book website](https://jupyterbook.org/customize/config.html).
 
 ### Deploying
 The site is built automatically using these two directories. All of the requirements are specificied in `website/requirements.txt`.

--- a/book/README.md
+++ b/book/README.md
@@ -3,7 +3,8 @@
 
 All the text for each chapter lives inside its own folder in the `content/` directory.
 
-Everything else is in the `website/`. The figures are present in the `book/content/figures/` directory.
+All figures associated to the chapters are stored in and linked from the `book/content/figures/` directory.
+Everything else is in the `website/` folder.
 
 ### Configuration
 - To change the table of contents (order of the chapters) see the `website/_data/toc.yml` file. Documentation can be found on the [TOC structure](https://jupyterbook.org/customize/toc.html).

--- a/book/README.md
+++ b/book/README.md
@@ -3,11 +3,11 @@
 
 All the text for each chapter lives inside its own folder in the `content/` directory.
 
-Everything else is in the `website/`. Importantly this includes the figures, which are in the `website/assets/figures/` directory.
+Everything else is in the `website/`. The figures are present in the `book/content/figures/` directory.
 
 ### Configuration
-- To change the table of contents (order of the chapters) see the `website/_data/toc.yml` file. Documentation can be found on the [jupyter book website](https://jupyter.org/jupyter-book/intro.html).
-- Same applies for more general configuration using `website/_config.yml`
+- To change the table of contents (order of the chapters) see the `website/_data/toc.yml` file. Documentation can be found on the [TOC structure](https://jupyterbook.org/customize/toc.html).
+- Same applies for more general configuration using `website/_config.yml` whose documentation can be viewed on [Configure book settings](https://jupyterbook.org/customize/config.html)
 
 ### Deploying
 The site is built automatically using these two directories. All of the requirements are specificied in `website/requirements.txt`.

--- a/book/README.md
+++ b/book/README.md
@@ -7,7 +7,9 @@ All figures associated to the chapters are stored in and linked from the `book/c
 Everything else is in the `website/` folder.
 
 ### Configuration
-- To change the table of contents (order of the chapters) see the `website/_data/toc.yml` file. Documentation can be found on the [TOC structure](https://jupyterbook.org/customize/toc.html).
+- The table of contents (TOC) defines the order of the chapters as they appear in the book.
+To change the TOC, please edit the `website/_data/toc.yml` file with correct information on the location of chapters, their corresponding file names and the relative location of the files. 
+Documentation on controlling the TOC structure can be found on the [jupyter book website](https://jupyterbook.org/customize/toc.html).
 - Same applies for more general configuration using `website/_config.yml` whose documentation can be viewed on [Configure book settings](https://jupyterbook.org/customize/config.html)
 
 ### Deploying

--- a/book/README.md
+++ b/book/README.md
@@ -7,8 +7,8 @@ All figures associated to the chapters are stored in and linked from the `book/c
 Everything else is in the `website/` folder.
 
 ### Configuration
-- The table of contents (TOC) defines the order of the chapters as they appear in the book.
-To change the TOC, please edit the `website/_data/toc.yml` file with correct information on the location of chapters, their corresponding file names and the relative location of the files. 
+- The table of contents (TOC) defines the order of chapters as they appear in the book.
+To change the TOC, please edit the `website/_data/toc.yml` file with correct information on file names and their relative locations in this repository. 
 Documentation on controlling the TOC structure can be found on the [jupyter book website](https://jupyterbook.org/customize/toc.html).
 - Same applies for more general configuration using `website/_config.yml`. 
 Documentation on configuring book settings can be found on the [jupyter book website](https://jupyterbook.org/customize/config.html).


### PR DESCRIPTION
## Summary
Fixes #1092 

Done:
- [x] The link should be redirected to correct webpage
- [x] Corrected path for searching out the figures 