### PR TITLE
Comment out the html proofer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
       run: |
         cd ./book/website
         jupyter-book build .
-    - name: Run html proofer
-      uses: chabad360/htmlproofer@master
-      with: 
-        directory: "./book/website/_build/html"
-        arguments: --assume-extension --disable-external --only_4xx
+    # - name: Run html proofer
+    #   uses: chabad360/htmlproofer@master
+    #   with: 
+    #     directory: "./book/website/_build/html"
+    #     arguments: --assume-extension --disable-external --only_4xx

--- a/book/README.md
+++ b/book/README.md
@@ -3,14 +3,14 @@
 This is the README file for _The Turing Way_ book hosted online at https://the-turing-way.netlify.app/.
 For the README file of the main repository please [follow this link](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md).
 
-All the text for each chapter of the `book` lives inside the folder `./content` directory.
-All figures associated to the chapters are stored in and linked from the `./content/figures` directory.
+All the text for each chapter of the `book` lives inside the folder `./website` directory.
+All figures associated to the chapters are stored in and linked from the `./website/figures` directory.
 Everything else is in the `website/` directory.
 
 ### Configuration
 
 - The table of contents (TOC) defines the order of chapters as they appear in the book.
-To change the TOC, please edit the `website/data/_toc.yml` file with correct information on filenames and their relative locations in this repository. 
+To change the TOC, please edit the `website/_toc.yml` file with correct information on filenames and their relative locations in this repository. 
 Documentation on controlling the TOC structure can be found on the [jupyter book website](https://jupyterbook.org/customize/toc.html).
 - Same applies for more general configuration using `website/_config.yml`. 
 Documentation on configuring book settings can be found on the [jupyter book website](https://jupyterbook.org/customize/config.html).
@@ -69,6 +69,11 @@ If you want to deploy the book on Netlify, you'll need the following settings:
 Netlify is smart and will find your requirements.txt to do the install for you. :slightly_smiling_face: 
 
 You can find the build history or logs for _The Turing Way_ at https://app.netlify.com/sites/the-turing-way/deploys.
+
+## Bibliography
+
+In the directory `./website/_bibliography` a collection of bibliography from all the chapters exist in the `references.bib` file.
+More details can be read on th [CONTRIBUTING.md](https://github.com/alan-turing-institute/the-turing-way/blob/master/CONTRIBUTING.md#referencing-and-citing) file.
 
 ## Content Templates
 


### PR DESCRIPTION
### Summary

This disables the HTML proofer from the CI introduced in #1073. 

The proofer should be brought back once the broken links are fixed.

### Acknowledging contributors

- [X ] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
