### PR TITLE
Provide Dockerfile to build a local test environment for The Turing Way

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -344,6 +344,34 @@ You can build and host the book website locally. The steps are:
    jupyter-book build .
    ```
 
+### To build the book in a container
+
+1. Create an image containing all of the dependencies from top level directory:
+
+   ```
+   docker build . --tag the-turing-way
+   ```
+
+   or
+
+   ```
+   podman build . --tag the-turing-way
+   ```
+
+2. Build with `jupyter-book`:
+
+   ```
+   docker run --rm -v $(pwd):/usr/local the-turing-way jupyter-book build
+/usr/local/book/website
+   ```
+
+   or
+
+   ```
+   podman run --rm -v $(pwd):/usr/local localhost/the-turing-way jupyter-book
+build /usr/local/book/website
+   ```
+
 ## Style Guide
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:bionic
+RUN apt-get update \
+	&& apt-get install -y python3 python3-pip \
+	&& rm -rf /var/lib/apt/lists/*
+RUN python3 -m pip install --upgrade pip setuptools wheel
+COPY ./book/website/requirements.txt requirements.txt
+RUN pip install -r requirements.txt


### PR DESCRIPTION
### Summary

This solution provides a Dockerfile to build a local container from an
ubuntu 18.04 Bionic Beaver base image. By prividing a similar
environment to the one in the CI (`.github/workflows/ci.yml`), we are
more likely to be able to build the book successfully on a local machine
for testing.

Fixes #1187

### List of changes proposed in this PR (pull-request)

* Add a Dockerfile that defines a reproducible environment for the book
* Update `CONTRIBUTING.md` to provide instructions on running the book.

### What should a reviewer concentrate their feedback on?

I am curious wha tyou think of this approach. Previously there had been a `docker-compose.yml` file. I think that creating just a `Dockerfile` might make sense because the image can be created and re-used without such a long delay each time a change is made.

I haven't been able to test the Docker related commands at home because I only have a Fedora machine which runs podman (which *should* be compatible).

### Acknowledging contributors

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file.