### PR TITLE
Changes from List of continuous integration services #1070

### DIFF
--- a/book/website/_toc.yml
+++ b/book/website/_toc.yml
@@ -149,6 +149,8 @@
   - title: Continuous Integration
     file: reproducible-research/ci
     sections:
+    - title: Continuous integration options
+      file: reproducible-research/ci/ci-options
     - title: Continuous integration with Travis
       file: reproducible-research/ci/ci-travis
     - title: Best practices and recommendations

--- a/book/website/reproducible-research/ci/ci-options.md
+++ b/book/website/reproducible-research/ci/ci-options.md
@@ -1,0 +1,11 @@
+### What are the options for CI service providers?
+
+There are many CI service providers, such as GitHub Actions and Travis CI. Each of these services has its own advantages and disadvantages. In this section we provide a brief overview with links to examples to help you select the most suitable one for you.
+
+ - [Travis CI](https://travis-ci.com/), for some examples see [the next section](#What_is_Travis_and_how_does_it_work) and the [Travis tutorial](https://docs.travis-ci.com/user/tutorial/).
+ - [GitHub Actions](https://help.github.com/en/actions), for some examples see the [language and framework guides](https://help.github.com/en/actions/language-and-framework-guides) and [this tutorial](https://github.com/NLESC-JCER/ci_for_science#-github-actions).
+ - [Circle CI](https://circleci.com/), for some examples see [here](https://circleci.com/docs/2.0/project-walkthrough/) and [here](https://circleci.com/docs/2.0/hello-world/).
+ - [GitLab CI](https://docs.gitlab.com/ee/ci/), for some examples the [GitLab CI examples](https://docs.gitlab.com/ee/ci/examples/README.html) and [this tutorial](https://github.com/NLESC-JCER/ci_for_science#-gitlab-ci).
+ - [Azure Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/), for some examples see the [ecosystem support page](https://docs.microsoft.com/en-us/azure/devops/pipelines/ecosystems/?view=azure-devops) and [this tutorial](https://github.com/trallard/ci-research).
+
+A more extensive list of CI service providers can be found [here](https://www.software.ac.uk/resources/guides/hosted-continuous-integration).

--- a/book/website/reproducible-research/ci/ci-travis.md
+++ b/book/website/reproducible-research/ci/ci-travis.md
@@ -2,8 +2,6 @@
 
 ## Overview of Travis
 
-There are a number of CI tools available, such as Circle (tutorials [here](https://circleci.com/docs/2.0/project-walkthrough/) and [here](https://circleci.com/docs/2.0/hello-world/)).
-A list of other CI tools can be found [here](https://www.software.ac.uk/resources/guides/hosted-continuous-integration).
 In this chapter we will focus on [Travis](https://travis-ci.org/) because it's free (if your code is openly available), widely used, and well integrated with the version control platform [GitHub](https://github.com/).
 
 To use Travis you will need to add a file to your project called `.travis.yml` which describes the computational environment to run the project in, and includes a script to run your tests. See the chapter on reproducible computational environments for more information on them, including writing `.yml` files to specify them. See the chapter on testing for information on writing and automating tests. The `.travis.yml` file has a number of other capabilities, which will be described [later](#After_success) along with more [detailed instructions](#Setting_up_the_computational_environment) for writing these files.


### PR DESCRIPTION
### Summary

Fixes #927
This is a new version of PR #1070, based on most recent master.

The CI chapter currently focuses (mostly) on Travis, while other services (CircleCI, Github Action) are becoming very good alternatives. This PR adds more alternatives and links to examples on how to use them

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
Alternatives to be considered:

- [ ]  Detailed description of Circle CI
- [ ]  Detailed description of Gitlab CI
- [ ]  Detailed description of Github actions
- [ ]  Detailed description of Azure pipelines

### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [x] Everything looks ok?


### Acknowledging contributors

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file.
