### PR TITLE
Fix PR-based CI to account for files that have been deleted

### DIFF
--- a/tests/lorem-ipsums.py
+++ b/tests/lorem-ipsums.py
@@ -54,13 +54,13 @@ def check_changed_files(pr_num, bad_phrase=BAD_PHRASE):
 
     for filename in filenames:
 	    try:
-            f = open(
-                os.path.join(ABSOLUTE_HERE, filename), encoding="utf8", errors="ignore"
-            )
-            text = f.read()
-            text = remove_comments(text)
-            if bad_phrase in text.lower():
-                failed.append(filename.name)
+            with open(
+            os.path.join(ABSOLUTE_HERE, filename), encoding="utf8", errors="ignore"
+            ) as f:
+                text = f.read()
+                text = remove_comments(text)
+                if bad_phrase in text.lower():
+                    failed.append(filename.name)
         except FileNotFoundError:
             pass
 

--- a/tests/lorem-ipsums.py
+++ b/tests/lorem-ipsums.py
@@ -53,13 +53,16 @@ def check_changed_files(pr_num, bad_phrase=BAD_PHRASE):
     failed = []
 
     for filename in filenames:
-        f = open(
-            os.path.join(ABSOLUTE_HERE, filename), encoding="utf8", errors="ignore"
-        )
-        text = f.read()
-        text = remove_comments(text)
-        if bad_phrase in text.lower():
-            failed.append(filename.name)
+	try:
+            f = open(
+                os.path.join(ABSOLUTE_HERE, filename), encoding="utf8", errors="ignore"
+            )
+            text = f.read()
+            text = remove_comments(text)
+            if bad_phrase in text.lower():
+                failed.append(filename.name)
+        except FileNotFoundError:
+	    pass
 
     return failed
 

--- a/tests/lorem-ipsums.py
+++ b/tests/lorem-ipsums.py
@@ -53,7 +53,7 @@ def check_changed_files(pr_num, bad_phrase=BAD_PHRASE):
     failed = []
 
     for filename in filenames:
-	try:
+	    try:
             f = open(
                 os.path.join(ABSOLUTE_HERE, filename), encoding="utf8", errors="ignore"
             )
@@ -62,7 +62,8 @@ def check_changed_files(pr_num, bad_phrase=BAD_PHRASE):
             if bad_phrase in text.lower():
                 failed.append(filename.name)
         except FileNotFoundError:
-	    pass
+            pass
+
 
     return failed
 

--- a/tests/lorem-ipsums.py
+++ b/tests/lorem-ipsums.py
@@ -53,7 +53,7 @@ def check_changed_files(pr_num, bad_phrase=BAD_PHRASE):
     failed = []
 
     for filename in filenames:
-	    try:
+        try:
             with open(
             os.path.join(ABSOLUTE_HERE, filename), encoding="utf8", errors="ignore"
             ) as f:

--- a/tests/no-bad-latin.py
+++ b/tests/no-bad-latin.py
@@ -98,16 +98,16 @@ def read_and_check_files(files):
 	        try:
                 with open(os.path.join(ABSOLUTE_HERE, filename), encoding="utf8", errors="ignore") as f:
                     text = f.read()
-                text = remove_comments(text)
+                    text = remove_comments(text)
 
-                for latin_type in bad_latin:
-                    if latin_type in text.lower():
-                        lines = get_lines(text.lower(), latin_type)
-                        for line in lines:
-                            failing_files[os.path.abspath(filename)] = {
-                                "latin_type": latin_type,
-                                "line": line,
-                            }
+                    for latin_type in bad_latin:
+                        if latin_type in text.lower():
+                            lines = get_lines(text.lower(), latin_type)
+                            for line in lines:
+                                failing_files[os.path.abspath(filename)] = {
+                                    "latin_type": latin_type,
+                                    "line": line,
+                                }
 	        except FileNotFoundError:
 		        pass
 

--- a/tests/no-bad-latin.py
+++ b/tests/no-bad-latin.py
@@ -95,7 +95,7 @@ def read_and_check_files(files):
         if filename in IGNORE_LIST:
             pass
         else:
-	    try:
+	        try:
                 with open(os.path.join(ABSOLUTE_HERE, filename), encoding="utf8", errors="ignore") as f:
                     text = f.read()
                 text = remove_comments(text)
@@ -108,8 +108,8 @@ def read_and_check_files(files):
                                 "latin_type": latin_type,
                                 "line": line,
                             }
-	    except FileNotFoundError:
-		pass
+	        except FileNotFoundError:
+		        pass
 
     return failing_files
 

--- a/tests/no-bad-latin.py
+++ b/tests/no-bad-latin.py
@@ -95,8 +95,10 @@ def read_and_check_files(files):
         if filename in IGNORE_LIST:
             pass
         else:
-	        try:
-                with open(os.path.join(ABSOLUTE_HERE, filename), encoding="utf8", errors="ignore") as f:
+            try:
+                with open(
+                os.path.join(ABSOLUTE_HERE, filename), encoding="utf8",
+                errors="ignore") as f:
                     text = f.read()
                     text = remove_comments(text)
 

--- a/tests/no-bad-latin.py
+++ b/tests/no-bad-latin.py
@@ -110,7 +110,7 @@ def read_and_check_files(files):
                                     "latin_type": latin_type,
                                     "line": line,
                                 }
-	        except FileNotFoundError:
+            except FileNotFoundError:
 		        pass
 
     return failing_files

--- a/tests/no-bad-latin.py
+++ b/tests/no-bad-latin.py
@@ -95,18 +95,21 @@ def read_and_check_files(files):
         if filename in IGNORE_LIST:
             pass
         else:
-            with open(os.path.join(ABSOLUTE_HERE, filename), encoding="utf8", errors="ignore") as f:
-                text = f.read()
-            text = remove_comments(text)
+	    try:
+                with open(os.path.join(ABSOLUTE_HERE, filename), encoding="utf8", errors="ignore") as f:
+                    text = f.read()
+                text = remove_comments(text)
 
-            for latin_type in bad_latin:
-                if latin_type in text.lower():
-                    lines = get_lines(text.lower(), latin_type)
-                    for line in lines:
-                        failing_files[os.path.abspath(filename)] = {
-                            "latin_type": latin_type,
-                            "line": line,
-                        }
+                for latin_type in bad_latin:
+                    if latin_type in text.lower():
+                        lines = get_lines(text.lower(), latin_type)
+                        for line in lines:
+                            failing_files[os.path.abspath(filename)] = {
+                                "latin_type": latin_type,
+                                "line": line,
+                            }
+	    except FileNotFoundError:
+		pass
 
     return failing_files
 

--- a/tests/no-bad-latin.py
+++ b/tests/no-bad-latin.py
@@ -111,7 +111,7 @@ def read_and_check_files(files):
                                     "line": line,
                                 }
             except FileNotFoundError:
-		        pass
+                pass
 
     return failing_files
 


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent. For example: "Fixes #58", or "Addresses (but does not close) #238". -->

When running CI in PRs, CI will fail with a `FileNotFoundError` if the PR deletes a file. This PR adds a `try/except` block to try to circumvent this. It could probably be handled more elegantly with something in the JSON packet from `pull_files.py`, but this should work for now.

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* `try/except` blocks added to `lorem-ipsums.py` and `no-bad-latin.py`


### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [ ] 🚨 Please check my indentation! Editing on GitHub web interface is hard 🙁 
- [ ] Everything looks ok?


### Acknowledging contributors

<!-- Please select the correct box -->

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
