### PR TITLE
Remove auto-formatting section and outdated image referencing in the style guide

### DIFF
--- a/book/website/community-handbook/style.md
+++ b/book/website/community-handbook/style.md
@@ -67,24 +67,3 @@ If that is not possible, use an alternative such as ‘meaning’ or ‘that is�
 Any text containing a Latin abbreviation will fail the continuos integration (CI) workflow of the _The Turing Way_ GitHub repository from passing successfully.
 
 *To avoid CI from failing, even in this chapter we have avoided to write those abbreviations and instead used an image to illustrate the above examples.*
-
-### Auto-formatting
-
-The Travis continuous-integration tests will check for formatting errors using [prettier.io](https://prettier.io). You can see a list of all files with style issues by looking at the Travis build logs, for example:
-
-```
-Checking formatting...
-book/content/introduction/introduction.md
-book/content/open_research/open_research.md
-Code style issues found in the above file(s). Forgot to run Prettier?
-The command "prettier --check ./book/website/**/*.md" exited with 1.
-```
-
-*Optional:* If you would like to apply auto-formatting when editing locally, we recommend [pre-commit](https://pre-commit.com/). To get started, run the following from your shell:
-
-```
-pip install pre-commit
-pre-commit install
-```
-
-Each time you attempt to commit a change with git, pre-commit will run the prettier auto-formatter and automagically fix any style issues.

--- a/book/website/community-handbook/style.md
+++ b/book/website/community-handbook/style.md
@@ -64,6 +64,6 @@ Instead of the second abbreviation in the table for *et-cetera* to indicate open
 Instead of third abbreviation in the table for *id est* that is often used to clarify a sentence, try (re)writing sentences to avoid the need to use it.
 If that is not possible, use an alternative such as ‘meaning’ or ‘that is’.
 
-Any text containing a Latin abbreviation will fail the continuos integration (CI) workflow of the _The Turing Way_ GitHub repository from passing successfully.
+Any chapter containing a Latin abbreviation will fail the continuos integration (CI) workflow of the _The Turing Way_ GitHub repository from passing successfully, which is tested by this [Python script](https://github.com/alan-turing-institute/the-turing-way/blob/master/tests/no-bad-latin.py).
 
 *To avoid CI from failing, even in this chapter we have avoided to write those abbreviations and instead used an image to illustrate the above examples.*

--- a/book/website/community-handbook/style/style-figures.md
+++ b/book/website/community-handbook/style/style-figures.md
@@ -1,6 +1,6 @@
-# Using images in _The Turing Way_
+# Using figures in _The Turing Way_
 
-You are welcome to add relevant images/figures and illustrations in the book chapters, however, please ensure that you attribute images fairly and avoid images that are either restricted from reuse or lack reproduction permissions.
+You are welcome to add relevant figures in the book chapters, however, please ensure that you attribute the image files fairly and avoid files that are either restricted from reuse or lack reproduction permissions.
 
 To ensure that, please follow these simple recommendations:
 
@@ -9,28 +9,30 @@ To ensure that, please follow these simple recommendations:
 - If you are using your images, they will be by-default included in this book under CC-BY 4.0 License.
 - Cite the image properly as directed by the image owners, “Image from the internet” is not enough.
 
+*Please note that we have used the term 'figure' to refer to an illustration that conveys information in the context of _The Turing Way_ chapters and the term 'image' is used to refer to the file object.*
+
 ## Image type, file size and location:
 
 Please upload .jpg or .png files that are under 1MB to allow them to load faster in the online book.
 If your file is larger than 1MB, please use a local image editing tools, or online tool like [IMG2GO](https://www.img2go.com/compress-image) to compress your file.
 
-Every image used in this book should be located in the file `_figure-list.md` in the directory `book/website/figures` of our [GitHub Repository](https://github.com/alan-turing-institute/the-turing-way/tree/master/book/website/figures).
-If you use a new image in any chapter, please add the file in the `figures` directory, and add details in the `_figure-list.md`.
+Every image file used in this book should be located in the file `_figure-list.md` in the directory `book/website/figures` of our [GitHub Repository](https://github.com/alan-turing-institute/the-turing-way/tree/master/book/website/figures).
+If you use a new image file, please add the file in the `figures` directory, and add details in the `_figure-list.md`.
 
-## Style for including image in a chapter:
+## Style for including figures in a chapter:
 
 All our chapters are written in markdown files.
-Therefore, using Markdown syntax to include an image in a Markdown file will work fine, for example, `![](../../figures/file-collection.jpg)`, where the relative path of the image is provided inside the round brackets '()'.
+Therefore, using Markdown syntax to include a figure in a Markdown file will work fine, for example, `![](../../figures/file-collection.jpg)`, where the relative path of the image file is provided inside the round brackets '()'.
 
 However, this formatting does not allow images to be responsive to screen sizes, making them inaccessible to read on small screens and smartphones.
-Furthermore, this doesn't allow authors to resize images in their chapters or cross reference them somewhere else in the book.
+Furthermore, this doesn't allow authors to resize figures in their chapters or cross reference them somewhere else in the book.
 
 Therefore, our recommendation is to use Markedly Structured Tex (MyST) format available in the current version of Jupyterbook.
 
-You can resize images to adjust how they appear in our chapters using the parameters: `height` (takes value in px, for example, 400px) or `scale` (takes value in percentage, for example, 50%), especially if your original image is large.
-Using the parameter: `name`, you can reference images in other chapters in a similar manner as defined in {ref}`ch-style-crossref`.
+You can resize figures to adjust how they appear in our chapters using the parameters: `height` (takes value in px, for example, 400px) or `scale` (takes value in percentage, for example, 50%), especially if your original figure is large.
+Using the parameter: `name`, you can reference figures in other chapters in a similar manner as defined in {ref}`ch-style-crossref`.
 
-All the components of your figure (image location, size and name) can be encapsulated in section within a markdown file using the following directive:
+All the components of your figure (figures location, size and name) can be encapsulated in section within a markdown file using the following directive:
 
 ````
 ```{figure} ../../figures/file-collection.jpg
@@ -41,7 +43,7 @@ name: file-collection
 ```
 ````
 
-This image can be referred in other files using the {ref} role like:
+This figure can be referred in other files using the {ref} role like:
 
 ```
 {ref}`file-collection`
@@ -50,17 +52,17 @@ This image can be referred in other files using the {ref} role like:
 ## Title:
 
 Titles should be short and concise and hold a reference to the source where they are taken from.
-For example, we can write the title *_The Turing Way_ project illustration by Scriberia. Original version on Zenodo. http://doi.org/10.5281/zenodo.3695300* below the image.
+For example, we can write the title *_The Turing Way_ project illustration by Scriberia. Original version on Zenodo. http://doi.org/10.5281/zenodo.3695300* below the figure.
 
 ## Alternative text:
 
 Alternative text or Alt text are used for describing the appearance and function of an image on an HTML page.
-Our example image can be explained with this sentence: *Two people happily browsing files in a drawer of documents.*
+Our example figure can be explained with this sentence: *Two people happily browsing files in a drawer of documents.*
 
-Adding alternative text to images is one of the first principles of web accessibility.
-Screen reader software can read an alt text to better explain the content with images to its users.
+Adding alternative text to figure is one of the first principles of web accessibility.
+Screen reader software can read an alt text to better explain the content of the figure to its users.
 
-All the components of your image (image location, size, name, alt text and title) can be encapsulated in section within a markdown file using the following directive:
+All the components of your figure (image file location, size, name, alt text and title) can be encapsulated in section within a markdown file using the following directive:
 
 ````
 ```{figure} ../../figures/file-collection.jpg
@@ -73,7 +75,7 @@ _The Turing Way_ project illustration by Scriberia. Original version on Zenodo. 
 ```
 ````
 
-Another advantage of using alt text is when an image file cannot be loaded in a browser, or the link to the image breaks, it is displayed in place of an image like shown below:
+Another advantage of using alt text is when an image cannot be loaded in a browser, or the link to the image breaks, it is displayed in place of an figure like shown below:
 
 ```{figure} ../figures/file-collection.jpg
 ---
@@ -84,7 +86,7 @@ alt: Two people happily browsing files in a drawer of documents.
 _The Turing Way_ project illustration by Scriberia. Original version on Zenodo. http://doi.org/10.5281/zenodo.3695300.
 ```
 
-When all these components are used correctly, an image included in a file will be rendered in the online book like in this page:
+When all these components are used correctly, a figure included in a file will be rendered in the online book like in this page:
 
 ```{figure} ../../figures/file-collection.jpg
 ---

--- a/book/website/community-handbook/style/style-figures.md
+++ b/book/website/community-handbook/style/style-figures.md
@@ -14,62 +14,27 @@ To ensure that, please follow these simple recommendations:
 Every image used in this book is located in the file `_figure-list.md` in the directory `book/website/figures` of our [GitHub Repository](https://github.com/alan-turing-institute/the-turing-way/tree/master/book/website/figures).
 If you use a new image in any chapter, please add the file in the `figures` directory, and add details in the `_figure-list.md`.
 
-All our chapters are written in markdown files.
-You can use the following Markdown syntax, where the relative path of the image is provided inside the round brackets '()':
-
-`![](../../figures/file-collection.jpg)`
-
-This is rendered in an online book (this page), like below:
-
-![](../../figures/file-collection.jpg)
-
-## Alternative text:
-
-Alternative text or Alt text are used for describing the appearance and function of an image on an HTML page.
-
-Adding alternative text to images is one of the first principles of web accessibility.
-Screen reader software can read an alt text that can help visually impaired users to better understand the content with images.
-
-In Markdown, the alt text for the image can be written inside the square brackets `[]`:
-
-```![Two folks happily looking in a drawer of documents and looking at different files.](../../figures/file-collection.jpg)```
-
-If an image file cannot be loaded in a browser, or the link to the image breaks, alt text is displayed in place of an image like shown below:
-
-![Two folks happily looking in a drawer of documents and looking at different files.](../figures/file-collection.jpg)
-
-## Title:
-
-Titles should be short and concise and hold a reference to the source where they are taken from.
-For example, we can use "*_The Turing Way_ project illustration by Scriberia. Original version on Zenodo. http://doi.org/10.5281/zenodo.3695300*" under the image as the title.
-
 ## Style for including image in a chapter:
 
-All the components of your figure (image, alt text and title) can be encapsulated in a table within a markdown file using the following directive:
+All our chapters are written in markdown files.
+Therefore, using Markdown syntax to include an image in a Markdown file will work fine, for example, `![](../../figures/file-collection.jpg)`, where the relative path of the image is provided inside the round brackets '()'.
 
-```
-| ![Two folks happily looking in a drawer of documents and looking at different files.](../figures/file-collection.jpg)        |
-| ------------------------------------------------------------------------------------ |
-| _The Turing Way_ project illustration by Scriberia. Original version on Zenodo. http://doi.org/10.5281/zenodo.3695300. |
-```
-**When you include a figure in a chapter you are writing, please add the details in the `book/content/figures` directory.**
+However, this formatting does not allow images to be responsive to screen sizes, making them inaccessible to read on small screens and smartphones.
+Furthermore, this doesn't allow authors to resize images in their chapters or cross reference them somewhere else in the book.
 
-## Using figures that can be referenced
+Therefore, our recommendation is to use Markedly Structured Tex (MyST) format available in the current version of Jupyterbook.
 
-The current version of Jupyterbook uses Markedly Structured Tex (MyST), which allows the inclusion of figures that can be referenced in other chapters in a similar manner as defined in {ref}`ch-style-crossref`.
+You can resize figures using the parameters: "height" (takes value in px, for example, 400px) or "scale" (takes value in percentage, for example, 50%), especially if your original image is large.
+Using the parameter" "name", you can reference figures in other chapters in a similar manner as defined in {ref}`ch-style-crossref`.
 
-There is another advantage of resizing your figures using the "height" (takes value in px, for example, 400px) or "scale" (takes value in percentage, for example, 50%) parameters, especially if your original image is large.
-
-To include a figure, use this pattern:
+All the components of your figure (image location, size and name) can be encapsulated in section within a markdown file using the following directive:
 
 ````
-```{figure} ../figures/file-collection.jpg
+```{figure} ../../figures/file-collection.jpg
 ---
 height: 500px
 name: file-collection
-alt: Two people happily looking in a drawer of documents and looking at different files.
 ---
-_The Turing Way_ project illustration by Scriberia. Original version on Zenodo. http://doi.org/10.5281/zenodo.3695300.
 ```
 ````
 
@@ -77,6 +42,56 @@ This figure can be referred in other files using the {ref} role like:
 
 ```
 {ref}`file-collection`
+```
+
+## Title:
+
+Titles should be short and concise and hold a reference to the source where they are taken from.
+For example, we can write the title "*_The Turing Way_ project illustration by Scriberia. Original version on Zenodo. http://doi.org/10.5281/zenodo.3695300*" below the image.
+
+## Alternative text:
+
+Alternative text or Alt text are used for describing the appearance and function of an image on an HTML page.
+For example, the above image can be explained by: "Two people happily browsing files in a drawer of documents."
+
+Adding alternative text to images is one of the first principles of web accessibility.
+Screen reader software can read an alt text to better explain the content with images to its users.
+
+All the components of your figure (image location, size, name, alt text and title) can be encapsulated in section within a markdown file using the following directive:
+
+````
+```{figure} ../../figures/file-collection.jpg
+---
+height: 500px
+name: file-collection
+alt: Two people happily browsing files in a drawer of documents.
+---
+_The Turing Way_ project illustration by Scriberia. Original version on Zenodo. http://doi.org/10.5281/zenodo.3695300.
+```
+````
+
+Another advantage of using alt text is when an image file cannot be loaded in a browser, or the link to the image breaks, it is displayed in place of an image like shown below:
+
+````
+```{figure} ../figures/file-collection.jpg
+---
+height: 500px
+name: file-collection
+alt: Two people happily browsing files in a drawer of documents.
+---
+_The Turing Way_ project illustration by Scriberia. Original version on Zenodo. http://doi.org/10.5281/zenodo.3695300.
+```
+````
+
+When all these components are used correctly, figures included in a file will be rendered in the online book like in this page:
+
+```{figure} ../../figures/file-collection.jpg
+---
+height: 500px
+name: file-collection
+alt: Two people happily browsing files in a drawer of documents.
+---
+_The Turing Way_ project illustration by Scriberia. Original version on Zenodo. http://doi.org/10.5281/zenodo.3695300.
 ```
 
 For more advanced parameters, please see the [JupyterBook Documentation](https://jupyterbook.org/content/figures.html).

--- a/book/website/community-handbook/style/style-figures.md
+++ b/book/website/community-handbook/style/style-figures.md
@@ -1,6 +1,6 @@
-# Using Figures in _The Turing Way_
+# Using images in _The Turing Way_
 
-You are welcome to add relevant images and illustrations in the book chapters, however, please ensure that you attribute images fairly and avoid images that are either restricted from reuse or lack reproduction permissions.
+You are welcome to add relevant images/figures and illustrations in the book chapters, however, please ensure that you attribute images fairly and avoid images that are either restricted from reuse or lack reproduction permissions.
 
 To ensure that, please follow these simple recommendations:
 
@@ -9,9 +9,12 @@ To ensure that, please follow these simple recommendations:
 - If you are using your images, they will be by-default included in this book under CC-BY 4.0 License.
 - Cite the image properly as directed by the image owners, “Image from the internet” is not enough.
 
-## Location of image files:
+## Image type, file size and location:
 
-Every image used in this book is located in the file `_figure-list.md` in the directory `book/website/figures` of our [GitHub Repository](https://github.com/alan-turing-institute/the-turing-way/tree/master/book/website/figures).
+Please upload .jpg or .png files that are under 1MB to allow them to load faster in the online book.
+If your file is larger than 1MB, please use a local image editing tools, or online tool like [IMG2GO](https://www.img2go.com/compress-image) to compress your file.
+
+Every image used in this book should be located in the file `_figure-list.md` in the directory `book/website/figures` of our [GitHub Repository](https://github.com/alan-turing-institute/the-turing-way/tree/master/book/website/figures).
 If you use a new image in any chapter, please add the file in the `figures` directory, and add details in the `_figure-list.md`.
 
 ## Style for including image in a chapter:
@@ -24,8 +27,8 @@ Furthermore, this doesn't allow authors to resize images in their chapters or cr
 
 Therefore, our recommendation is to use Markedly Structured Tex (MyST) format available in the current version of Jupyterbook.
 
-You can resize figures using the parameters: "height" (takes value in px, for example, 400px) or "scale" (takes value in percentage, for example, 50%), especially if your original image is large.
-Using the parameter" "name", you can reference figures in other chapters in a similar manner as defined in {ref}`ch-style-crossref`.
+You can resize images to adjust how they appear in our chapters using the parameters: `height` (takes value in px, for example, 400px) or `scale` (takes value in percentage, for example, 50%), especially if your original image is large.
+Using the parameter: `name`, you can reference images in other chapters in a similar manner as defined in {ref}`ch-style-crossref`.
 
 All the components of your figure (image location, size and name) can be encapsulated in section within a markdown file using the following directive:
 
@@ -38,7 +41,7 @@ name: file-collection
 ```
 ````
 
-This figure can be referred in other files using the {ref} role like:
+This image can be referred in other files using the {ref} role like:
 
 ```
 {ref}`file-collection`
@@ -47,17 +50,17 @@ This figure can be referred in other files using the {ref} role like:
 ## Title:
 
 Titles should be short and concise and hold a reference to the source where they are taken from.
-For example, we can write the title "*_The Turing Way_ project illustration by Scriberia. Original version on Zenodo. http://doi.org/10.5281/zenodo.3695300*" below the image.
+For example, we can write the title *_The Turing Way_ project illustration by Scriberia. Original version on Zenodo. http://doi.org/10.5281/zenodo.3695300* below the image.
 
 ## Alternative text:
 
 Alternative text or Alt text are used for describing the appearance and function of an image on an HTML page.
-For example, the above image can be explained by: "Two people happily browsing files in a drawer of documents."
+Our example image can be explained with this sentence: *Two people happily browsing files in a drawer of documents.*
 
 Adding alternative text to images is one of the first principles of web accessibility.
 Screen reader software can read an alt text to better explain the content with images to its users.
 
-All the components of your figure (image location, size, name, alt text and title) can be encapsulated in section within a markdown file using the following directive:
+All the components of your image (image location, size, name, alt text and title) can be encapsulated in section within a markdown file using the following directive:
 
 ````
 ```{figure} ../../figures/file-collection.jpg
@@ -72,7 +75,6 @@ _The Turing Way_ project illustration by Scriberia. Original version on Zenodo. 
 
 Another advantage of using alt text is when an image file cannot be loaded in a browser, or the link to the image breaks, it is displayed in place of an image like shown below:
 
-````
 ```{figure} ../figures/file-collection.jpg
 ---
 height: 500px
@@ -81,9 +83,8 @@ alt: Two people happily browsing files in a drawer of documents.
 ---
 _The Turing Way_ project illustration by Scriberia. Original version on Zenodo. http://doi.org/10.5281/zenodo.3695300.
 ```
-````
 
-When all these components are used correctly, figures included in a file will be rendered in the online book like in this page:
+When all these components are used correctly, an image included in a file will be rendered in the online book like in this page:
 
 ```{figure} ../../figures/file-collection.jpg
 ---


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent. For example: "Fixes #58", or "Addresses (but does not close) #238". -->

This PR removes the auto-formatting section of the [style guide](https://the-turing-way.netlify.app/community-handbook/style.html). This section describes using a pre-commit hook and prettier.io, which were formerly part of the project but later removed in #908.

Fixes #1390 

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* Remove auto-formatting section

### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [ ] Everything looks ok?

### Acknowledging contributors

<!-- Please select the correct box -->

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
