### PR TITLE
Fix non-consecutive headers: CI subchapters

### DIFF
--- a/book/website/reproducible-research/ci/ci-options.md
+++ b/book/website/reproducible-research/ci/ci-options.md
@@ -1,4 +1,4 @@
-### What are the options for CI service providers?
+# What are the options for CI service providers?
 
 There are many CI service providers, such as GitHub Actions and Travis CI. Each of these services has its own advantages and disadvantages. In this section we provide a brief overview with links to examples to help you select the most suitable one for you.
 

--- a/book/website/reproducible-research/overview/overview-resources.md
+++ b/book/website/reproducible-research/overview/overview-resources.md
@@ -2,10 +2,10 @@
 # Resources for reproducibility chapter
 For additional resources like videos and reference papers on reproducibility, see the {ref}`rr-overview-resources-reading` and {ref}`rr-overview-resources-addmaterial` sections.
 
-### Checklist / Exercise
+## Checklist / Exercise
 - [ ] Define reproducibility for yourself.
 
-### What to learn next?
+## What to learn next?
 {ref}`rr-open` would be a good chapter to read next.
 If you want to start learning hands-on practices, we recommend reading the {ref}`rr-vcs` chapter next.
 


### PR DESCRIPTION
### Summary
Fix non-consecutive headers

Fixes #1421 

### List of changes proposed in this PR (pull-request)

* reproducible-research/ci/ci-options.md
* reproducible-research/ci/ci-options.md


### What should a reviewer concentrate their feedback on?

- [ ] Headers are consecutive in the above files

### Acknowledging contributors

<!-- Please select the correct box -->

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file.
- [X] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file: dlintott
