### PR TITLE
Minor cleanup for the github workflow page

### DIFF
--- a/book/website/reproducible-research/vcs/vcs-github.md
+++ b/book/website/reproducible-research/vcs/vcs-github.md
@@ -21,7 +21,7 @@ In order to collaborate with others, hosting services, such as GitHub, can store
 Usually, you will have a local repository and a *remote*, web-hosted repository.
 Your local repository is connected to the web-based clone.
 In technical terms, the web-based clone is a `remote` of the local repository. Usually, this remote is called "origin".
-Having a web-based remote allows you to *push* changes to your project online. 
+Having a web-based remote allows you to *push* changes to your project online.
 It enables others to obtain their own clone of your repository (a copy of your repository to their local computer), make changes, and submit a *pull request* that allows you to integrate their changes.
 For example, one can create an independent local copy of a project using the following Git command:
 
@@ -72,7 +72,7 @@ You can also make changes directly on the GitHub by editing the online repositor
 Others can also clone the repository to their computer by using:
 
 ```
-git clone https://GitHub.com/your_username/repository_name.Git
+git clone git@github.com:your-github-username/repository_name
 ```
 
 They can make and commit changes to the code without impacting the original, and push their changes to *their* online GitHub account using:
@@ -99,7 +99,7 @@ git push origin branch-name
 
 However, if you can not directly edit the repository (when you are not an owner or admin of the project), you will be able to share your work with the help of *pull requests*.
 A pull request allows a contributor to get the proposed changes from their branch or repository integrated into the master branch of the project.
-It is also possible to make pull requests via the command line (see the GitLab documentation [here](https://git-scm.com/docs/git-request-pull)). 
+It is also possible to make pull requests via the command line (see the GitLab documentation [here](https://git-scm.com/docs/git-request-pull)).
 
 (rr-vcs-github-contributing)=
 ## Contributing to Other Projects
@@ -115,18 +115,18 @@ Therefore, when working on different branches or forks of a repository, it is a 
 Using the fork button on the GitHub repository you wish to contribute to, create a copy of the repository in your account.
 The master repository that you forked will be referred to as the "upstream" repository.
 
-You can now work on your copy using the command line, via the following steps:
+You can now work on your copy using the command line, via the following steps (make sure you replace the placeholder user and repository names):
 
 1. Clone it to your local machine:
 
     ```
-    git clone git@github.com/your_username/forked_repository.git
+    git clone git@github.com:your-github-username/repository_name
     ```
 
-2. Add the 'upstream' repository to the list of remote repositories using a similar command as below (replace the upstream repository's users id and original repository name):
+2. Add the 'upstream' repository to the list of remote repositories using the ``git remote`` command:
 
     ```
-    git remote add upstream https://github.com/upstream_user's_username/original_repository.git
+    git remote add upstream git@github.com:upstream-github-username/repository_name
     ```
 
 3. Verify the new remote 'upstream' repository:

--- a/book/website/reproducible-research/vcs/vcs-github.md
+++ b/book/website/reproducible-research/vcs/vcs-github.md
@@ -16,7 +16,7 @@ For simplicity, we will use GitHub as an example to explain commands that are us
 (rr-vcs-github-local)=
 ## Create a Local Copy of an Online Repository
 
-So far, all Git commands introduced in this chapter concerned local, unconnected Git repositories.
+So far, all Git commands introduced in this chapter are concerned with local, unconnected Git repositories.
 In order to collaborate with others, hosting services, such as GitHub, can store a *clone* (a copy) of your local repository and expose it to others.
 Usually, you will have a local repository and a *remote*, web-hosted repository.
 Your local repository is connected to the web-based clone.
@@ -67,7 +67,7 @@ When you want to push them to your online version, similarly you do:
 git push origin branch_you_want_to_push_to
 ```
 
-You can also make changes directly on the GitHub by editing the online repository, and *pull* those changes locally by using the `git pull` command.
+You can also make changes directly on GitHub by editing the online repository, and *pull* those changes locally by using the `git pull` command.
 
 Others can also clone the repository to their computer by using:
 
@@ -177,7 +177,7 @@ git checkout my-other-branch
 git pull origin master
 ```
 
-When everything is  up-to-date, you can work on your branch and commit changes.
+When everything is up-to-date, you can work on your branch and commit changes.
 
 When you are ready to push your local commits to your forked repository (origin), use the following command.
 

--- a/book/website/reproducible-research/vcs/vcs-github.md
+++ b/book/website/reproducible-research/vcs/vcs-github.md
@@ -192,6 +192,12 @@ Now you can make a pull request!
 
 Before you create a branch, make sure you have all the upstream changes from the origin/master branch.
 
+
 **A word of caution on the `rebase` command**: While trying to keep your branches in sync, you may come across the `rebase` command.
 It tends to rewrite history and could be troublesome if not communicated with others working on the same branch. Try to avoid using the `rebase` command, and instead use `pull` or `fetch`+`merge`, as discussed in this section.
-You can find more details about Merging vs Rebasing [here](https://www.atlassian.com/git/tutorials/merging-vs-rebasing)
+You can find more details about [Merging vs Rebasing](https://www.atlassian.com/git/tutorials/merging-vs-rebasing).
+
+
+## Further reading
+- An [article on syncing a fork of a repository](https://help.github.com/en/articles/syncing-a-fork) to keep it up-to-date with the upstream repository.
+- Instructions if you wish to do it all [in the browser itself](https://github.com/KirstieJane/STEMMRoleModels/wiki/Syncing-your-fork-to-the-original-repository-via-the-browser).


### PR DESCRIPTION
### Summary

This just provides a minor cleanup to be self-consistent with naming and protocol to be used (https vs ssh), and removes links put under `here` words, which is widely considered avoidable. 

I avoided making contextual changes as it should be preceded by a discussion in #1489 and #1490 


### List of changes proposed in this PR (pull-request)

* use ssh, and consistent repo and user naming in git examples
* refactor links to not to be for "here"


### What should a reviewer concentrate their feedback on?

- [ ] Everything looks ok?


### Acknowledging contributors

<!-- Please select the correct box -->

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
