### PR TITLE
Upgrade Jupyter Book / Enable collaborative annotation in the book

### DIFF
--- a/book/website/_config.yml
+++ b/book/website/_config.yml
@@ -30,11 +30,10 @@ html:
   use_issues_button         : true # Whether to add an "Open issue" button to pages. If `true`, repository information in repository: must be filled in
   use_edit_page_button      : true  # Whether to add an "Suggest edit" button to pages. If `true`, repository information in repository: must be filled in
   baseurl                   : "https://the-turing-way.netlify.com"  # The base URL where your book will be hosted. Used for creating image previews and social links. for example: https://mypage.com/mybook/
-  navbar_footer_text        :
-    'Visit our <a href="https://github.com/alan-turing-institute/the-turing-way">GitHub Repository</a>
-    <div>
-    This book is powered by <a href="https://jupyterbook.org">Jupyter Book</a>
-    </div>'  # Will be displayed underneath the left navbar.
+  extra_navbar              : Visit our <a href="https://github.com/alan-turing-institute/the-turing-way">GitHub Repository</a>
+    <div>This book is powered by <a href="https://jupyterbook.org">Jupyter Book</a></div>
+  comments:
+    hypothesis: true 
 
 #######################################################################################
 # Launch button settings
@@ -52,17 +51,6 @@ repository:
 # Advanced and power-user settings
 sphinx:
   extra_extensions          :  # A list of extra extensions to load by Sphinx.
-  config                    : ""  # key-value pairs to directly over-ride the Sphinx configuration
+  config                    :  # key-value pairs to directly over-ride the Sphinx configuration
 
-#######################################################################################
-# Interactivity features
 
-launch_buttons:
-  binderhub_url: "https://mybinder.org"
-  
-#######################################################################################
-# Activate Hypothesis
-
-html:
-  comments:
-    hypothesis: true 

--- a/book/website/_config.yml
+++ b/book/website/_config.yml
@@ -59,3 +59,10 @@ sphinx:
 
 launch_buttons:
   binderhub_url: "https://mybinder.org"
+  
+#######################################################################################
+# Activate Hypothesis
+
+html:
+  comments:
+    hypothesis: true 

--- a/book/website/_static/myfile.css
+++ b/book/website/_static/myfile.css
@@ -1,0 +1,3 @@
+#site-navigation li > a {
+    font-size: 1.1em;
+  }

--- a/book/website/requirements.txt
+++ b/book/website/requirements.txt
@@ -5,7 +5,7 @@ numpy==1.19.0
 datascience==0.15.6
 folium==0.11.0
 matplotlib==3.2.2
-jupyter-book==0.8.3
+jupyter-book==0.7.9
 sphinx==2.4.4
 pydata-sphinx-theme==0.3.1
 sphinx-book-theme==0.0.30

--- a/book/website/requirements.txt
+++ b/book/website/requirements.txt
@@ -5,7 +5,7 @@ numpy==1.19.0
 datascience==0.15.6
 folium==0.11.0
 matplotlib==3.2.2
-jupyter-book==0.7.5
+jupyter-book==0.7.2
 sphinx==2.4.4
 pydata-sphinx-theme==0.3.1
 sphinx-book-theme==0.0.30

--- a/book/website/requirements.txt
+++ b/book/website/requirements.txt
@@ -9,4 +9,4 @@ jupyter-book==0.7.1
 sphinx==2.4.4
 pydata-sphinx-theme==0.3.1
 sphinx-book-theme==0.0.30
-node
+nodejs

--- a/book/website/requirements.txt
+++ b/book/website/requirements.txt
@@ -5,7 +5,7 @@ numpy==1.19.0
 datascience==0.15.6
 folium==0.11.0
 matplotlib==3.2.2
-jupyter-book==0.7.1
+jupyter-book==0.8.3
 sphinx==2.4.4
 pydata-sphinx-theme==0.3.1
 sphinx-book-theme==0.0.30

--- a/book/website/requirements.txt
+++ b/book/website/requirements.txt
@@ -9,3 +9,6 @@ jupyter-book==0.7.1
 sphinx==2.4.4
 pydata-sphinx-theme==0.3.1
 sphinx-book-theme==0.0.30
+libevent
+libffi
+node

--- a/book/website/requirements.txt
+++ b/book/website/requirements.txt
@@ -5,8 +5,8 @@ numpy==1.19.0
 datascience==0.15.6
 folium==0.11.0
 matplotlib==3.2.2
-jupyter-book==0.7.2
+jupyter-book==0.8.0
 sphinx==2.4.4
-pydata-sphinx-theme==0.3.1
-sphinx-book-theme==0.0.30
+pydata-sphinx-theme
+sphinx-book-theme
 nodejs

--- a/book/website/requirements.txt
+++ b/book/website/requirements.txt
@@ -5,7 +5,7 @@ numpy==1.19.0
 datascience==0.15.6
 folium==0.11.0
 matplotlib==3.2.2
-jupyter-book==0.7.9
+jupyter-book==0.7.5
 sphinx==2.4.4
 pydata-sphinx-theme==0.3.1
 sphinx-book-theme==0.0.30

--- a/book/website/requirements.txt
+++ b/book/website/requirements.txt
@@ -9,6 +9,4 @@ jupyter-book==0.7.1
 sphinx==2.4.4
 pydata-sphinx-theme==0.3.1
 sphinx-book-theme==0.0.30
-libevent
-libffi
 node

--- a/book/website/requirements.txt
+++ b/book/website/requirements.txt
@@ -2,11 +2,7 @@
 # Useful for MyBinder configuration
 pandas==1.0.5
 numpy==1.19.0
-datascience==0.15.6
-folium==0.11.0
 matplotlib==3.2.2
-jupyter-book==0.8.0
-sphinx==2.4.4
-pydata-sphinx-theme
-sphinx-book-theme
-nodejs
+datascience
+folium
+jupyter-book==0.8.2


### PR DESCRIPTION
After a discussion in slack regarding the book-layout, @lauracion and @SamGuay suggested implementing [hypothes.is](https://web.hypothes.is/). I gave it a try and made changes in `_config.yml`. After that, I tried to build up the Jupyter book locally and it worked. It became easy to highlight any text and to add any notes in the book.

<img width="1000" alt="Screenshot 2020-11-11 at 02 10 35" src="https://user-images.githubusercontent.com/53487593/98744666-24ec6880-23c3-11eb-8890-1921daf3dbf6.png">


### List of changes proposed in this PR (pull-request)

* *Implementing [hypothes.is](https://web.hypothes.is/) in the TW book .*

### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [ ] Everything looks ok?


### Acknowledging contributors

<!-- Please select the correct box -->

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file.
- [x] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->