### PR TITLE
Fix broken Relative Links in Chapter and Case Study templates

### DIFF
--- a/book/templates/case-study-template/case-study-template.md
+++ b/book/templates/case-study-template/case-study-template.md
@@ -81,7 +81,7 @@
 > For example, if you wrote your case study for the Guide for Reproducible Research, you may use this section to talk about anything new you learned about producing work that is reproducible.
 
 > To help with writing this section, we have curated some questions to get you thinking.
-> You can find the questions in the [reflection-questions.md](book/templates/case-study-template/reflection-questions.md) file.
+> You can find the questions in the [reflection-questions.md](./reflection-questions.md) file.
 > Please note that these questions are not exhaustive or definititve. 
 > You are encouraged to improve on them in a pull request.
 

--- a/book/templates/chapter-template/README.md
+++ b/book/templates/chapter-template/README.md
@@ -43,7 +43,7 @@ We encourage you to use them to structure your content.
 
 ### `chapter-landing-page.md`:
 
-At the top-level of the `chapter-template` folder, you will find the [`chapter-landing-page.md`](templates/chapter-template/chapter-landing-page.md) file where you can write content for your chapter's landing page.
+At the top-level of the `chapter-template` folder, you will find the [`chapter-landing-page.md`](./chapter-landing-page.md) file where you can write content for your chapter's landing page.
 
 The landing page is where your chapter begins, and where you should introduce and summarise the rest of your chapter's content.
 The landing page should also inform readers why the chapter may be useful to them and what prior knowledge they should have to understand the chapter better.
@@ -52,7 +52,7 @@ When adding your chapter to _The Turing Way_ book, your landing page should live
 
 ### `chapter-content.md`:
 
-Inside the `chapter-content` folder, you will find the [`chapter-content.md`](templates/chapter-template/chapter-content/chapter-content.md) file where you can write about the individual topics that make up your chapter.
+Inside the `chapter-content` folder, you will find the [`chapter-content.md`](./chapter-content/chapter-content.md) file where you can write about the individual topics that make up your chapter.
 This can be referred to as subchapters.
 
 For example, if you were writing a chapter on [Open Science](https://en.wikipedia.org/wiki/Open_science) with a focus on its different interpretations, this file is where you would individually write about the various schools of thought in Open Science (one of which could be The Infrastructure School of Thought, for example).
@@ -62,9 +62,9 @@ This file should be included in the sub-folder named after your chapter.
 
 ### `chapter-personal-stories`:
 
-The [`chapter-personal-stories.md`](book/templates/chapter-template/chapter-content/chapter-personal-stories.md) file, located in the `chapter-content` folder, is where you may include a short case study of an individual who practices your chapter's concepts in their work.
+The [`chapter-personal-stories.md`](./chapter-content/chapter-personal-stories.md) file, located in the `chapter-content` folder, is where you may include a short case study of an individual who practices your chapter's concepts in their work.
 
-Much like a Guide-wide [case study](book/templates/case-study-template/case-study-template.md), a personal story is a space where the subject of the case study provides their perspectives on how the concepts in this chapter has affected their workflow.
+Much like a Guide-wide [case study](../case-study-template/case-study-template.md), a personal story is a space where the subject of the case study provides their perspectives on how the concepts in this chapter has affected their workflow.
 
 _**Including a personal story in your chapter is optional; However, readers will greatly benefit from a real world application of the key ideas your chapter introduces.**_
 
@@ -74,7 +74,7 @@ It should also be added to the chapter's sub-folder
 
 ### `chapter-checklist.md`:
 
-You will find the [`chapter-checklist.md`](templates/chapter-template/chapter-content/chapter-checklist.md) file in the `chapter-content` folder.
+You will find the [`chapter-checklist.md`](./chapter-content/chapter-checklist.md) file in the `chapter-content` folder.
 This file should contain action points you want your readers to take based on the chapter's content.
 Ideally, these action points should reinforce the key concepts of your chapter in a practical way.
 
@@ -82,7 +82,7 @@ Add this file to your chapter's sub-folder as well.
 
 ### `chapter-resources.md`:
 
-This [file](templates/chapter-template/chapter-content/chapter-resources.md) can be found in the `chapter-content` folder.
+This [file](./chapter-content/chapter-resources.md) can be found in the `chapter-content` folder.
 Use `chapter-resources.md` to tell readers what topics to explore next and where to find more information about the concepts covered in your chapter.
 
 `chapter-resources.md` should also be located in the sub-folder named after your chapter.
@@ -114,7 +114,7 @@ This could be `open-science-checklist.md` or `open-science-resources.md` for Che
 
 ### Add your new files to the book's table of contents
 
-The book-wide table of contents lives in the `_toc.yml` [file](book/website/_toc.yml).
+The book-wide table of contents lives in the `_toc.yml` [file](../../../book/website/_toc.yml).
 This file structures _The Turing Way_ and defines the order in which chapters appear.
 Your chapter's files should be added to the `_toc.yml` as appropriate.
 
@@ -151,10 +151,5 @@ For each term, cross-reference to the subchapter/section where you explained it.
 
 The content of the templates are meant to guide and structure your writing.
 Please remove all of the template's placeholders, tips, and suggestions from your chapter before you submit your PR for review.
-
-### Follow the style and consistency guidelines
-
-As you write your chapter, keep _The Turing Way's_ [style](https://the-turing-way.netlify.app/community-handbook/style.html) and [consistency](https://the-turing-way.netlify.app/community-handbook/consistency.html) recommendations in mind.
-This ensures that your new content is accessible, and fits the overall style, structure, and formatting of _The Turing Way_ book.
 
 Happy Writing!


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent. For example: "Fixes #58", or "Addresses (but does not close) #238". -->

Fixes #<NUM>

Github does not recognise the way I implemented relative links in the chapter and case study templates. I have updated the links accordingly and they work now. I also caught a piece of repeated text in the chapter template, which I have removed.

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- Correct broken relative links
- Remove repeated text


### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [ ] Everything looks ok?


### Acknowledging contributors

<!-- Please select the correct box -->

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file.
- [x] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
