### PR TITLE
restore custom styling chapter under style guide

### DIFF
--- a/book/website/_toc.yml
+++ b/book/website/_toc.yml
@@ -329,6 +329,8 @@
       file: community-handbook/style/style-figures
     - title: Glossary, Special Blocks and More Styling
       file: community-handbook/style/style-more-styling
+    - title: Custom Styling
+      file: community-handbook/style/style-custom-styling
   - title: Maintaining Consistency
     file: community-handbook/consistency
     sections:

--- a/book/website/community-handbook/style/style-custom-styling.md
+++ b/book/website/community-handbook/style/style-custom-styling.md
@@ -1,0 +1,74 @@
+(ch-style-custom-styling)=
+# Custom Styling
+
+Although content contributed to _The Turing Way_ should be written in {ref}`Markdown <ch-consistency-formatting-hr-markdown>` where possible, sometimes, `HTML` syntax may be necessary to format your contribution the way you desire.
+Already, Jupyter Book converts Markdown syntax to `HTML`, making it possible to have a web version of _The Turing Way_ book.
+As a result, writing your own custom `HTML` may introduce some variation in the way your new content appears online compared to the rest of the book.
+
+To minimise this disparity, _The Turing Way_ maintains book-wide [stylesheets](https://github.com/alan-turing-institute/the-turing-way/blob/master/book/website/_static/book-stylesheet.css) that control the look and feel of the book's content.
+When including `HTML` in your contributions, please refer to these stylesheets and add the relevant classes and IDs defined there to your `HTML` elements.
+This ensures that your new content fits the overall style of _The Turing Way_ book.
+
+In this subchapter, we provide an explanation of how to leverage the book's stylesheets to style your contributions in sample use-cases.
+If you want to improve the style of the book, this subchapter also provides a brief overview of how to do so.
+
+(ch-style-custom-styling-stylesheets)=
+## Using the Stylesheets
+
+(ch-style-custom-styling-stylesheets-videos)=
+### Videos
+
+While it is possible to embed images and GIFs in your content using Markdown syntax, it is currently only possible to embed videos with `HTML`.
+More so, we do not recommend adding videos directly to _The Turing Way's_ Github repository as video files are usually large and will make the book load much slower, especially for readers with slow internet connections.
+
+To add a video to your contribution, first upload it to _The Turing Way's_ Youtube channel, then copy/paste the `HTML` code that is generated when you:
+1. Click on the `Share` option underneath the video,
+1. And then click on the `Embed` option from the range of options that appear.
+
+
+The `HTML` code you copy will be an [`iframe`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe) element.
+For example:
+
+```
+<iframe width="560" height="315" src="https://www.youtube.com/embed/MdOS6tPq8fc" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+```
+
+By default, `iframes` are not responsive, meaning that the video you just embedded will be inaccessible to readers on mobile devices.
+To fix this, _The Turing Way's_ stylesheets define classes and styling that allow `iframes` to resize and fit the screen the book is read from.
+
+To leverage this custom styling, wrap the `iframe` in `div` tags and give the `div` element a `video-container` class. For example:
+
+```
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/MdOS6tPq8fc" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+```
+
+The code above then renders as follows:
+
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/MdOS6tPq8fc" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+
+(ch-style-custom-styling-improvements)=
+## Improving _The Turing Way's_ Styling
+
+Jupyter Book works by converting Markdown syntax to `HTML`.
+Therefore, to improve the overall styling of the book, `CSS` rules should target the `HTML` elements that Jupyter Book generates.
+
+Before writing any CSS, inspect the book's HTML source code first.
+This gives you an idea of what elements to target, and may help you figure out how to structure your CSS rules.
+
+All web browsers allow you to view the source code of websites easily.
+On computers running the Windows OS, this is done using `CTRL + U`.
+For computers running Mac OS, this is done using `Option + Command + U`.
+
+Once you have determined the element(s) you want to modify, write your CSS in _The Turing Way's_ [stylesheet file](https://github.com/alan-turing-institute/the-turing-way/blob/master/book/website/_static/book-stylesheet.css).
+If, for example, you wanted to change the `font-family` of the paragraph text across the entire _The Turing Way_ book, then you could add the following CSS rule to the stylesheets which target
+all elements with a `<p>` tag:
+
+```
+p {
+    font-family: georgia, garamond, serif;
+}
+```

--- a/book/website/community-handbook/style/style-custom-styling.md
+++ b/book/website/community-handbook/style/style-custom-styling.md
@@ -72,3 +72,5 @@ p {
     font-family: georgia, garamond, serif;
 }
 ```
+
+If you think that the styling introduced in _The Turing way_ can be useful for other Jupyter Book users, please consider making an upstream contribution to the project by creating a new GitHub issue and starting a discussion with their maintainers: [https://github.com/executablebooks/jupyter-book/issues](https://github.com/executablebooks/jupyter-book/issues).


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent. For example: "Fixes #58", or "Addresses (but does not close) #238". -->

Fixes #1657 

* In a merge conflict, this file was lost which I may have overlooked, restoring it in this PR

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* Restoring the subchapter on custom styling by @paulowoicho 

### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [ ] Everything looks ok?


### Acknowledging contributors

<!-- Please select the correct box -->

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
