### PR TITLE
Indent numbered list blocks to avoid number reset

### DIFF
--- a/book/website/reproducible-research/vcs/vcs-github.md
+++ b/book/website/reproducible-research/vcs/vcs-github.md
@@ -119,41 +119,41 @@ You can now work on your copy using the command line, via the following steps:
 
 1. Clone it to your local machine:
 
-```
-git clone git@github.com/your_username/forked_repository.git
-```
+    ```
+    git clone git@github.com/your_username/forked_repository.git
+    ```
 
 2. Add the 'upstream' repository to the list of remote repositories using a similar command as below (replace the upstream repository's users id and original repository name):
 
-```
-git remote add upstream https://github.com/upstream_user's_username/original_repository.git
-```
+    ```
+    git remote add upstream https://github.com/upstream_user's_username/original_repository.git
+    ```
 
 3. Verify the new remote 'upstream' repository:
 
-```
-git remote -v
-```
+    ```
+    git remote -v
+    ```
 
 4. Update your fork with the latest upstream changes, by first fetching the upstream repository's branches and latest commits to bring them into your repository:
 
-```
-git fetch upstream
-```
+    ```
+    git fetch upstream
+    ```
 
 5. View all branches, including those from upstream:
 
-```
-git branch -va
-```
+    ```
+    git branch -va
+    ```
 
 Make sure that you are on your master branch locally, if not, then checkout your master branch using the command `git checkout master`
 
 6. Keep your fork updated by merging those commits (fetched from the upstream) to your own local master branch.
 
-```
-git merge upstream/master
-```
+    ```
+    git merge upstream/master
+    ```
 
 Now, your local master branch is up-to-date with everything modified upstream.
 If there are no unique commits on the local master branch, git will simply perform a fast-forward.


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent. For example: "Fixes #58", or "Addresses (but does not close) #238". -->

Fixes small grammatical error regarding noun determiner.

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* On the Netlify-hosted _Turing Way_, the numbered list indices are reset because of the code blocks at each point. This means the list looks as below, with 1. as the index for all points. To fix this, indent the code blocks with 4 spaces.
<img width="683" alt="image" src="https://user-images.githubusercontent.com/8530685/108604255-738fa280-73b5-11eb-95f4-8c82b5a1545e.png">


### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [x] Ensure fix remedies the list indexing on Netlify.


### Acknowledging contributors

<!-- Please select the correct box -->

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file.
- [x] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file: @inwaves
