### PR TITLE
Remove duplication of "Disambiguation" list

### DIFF
--- a/book/website/reproducible-research/renv/renv-binder.md
+++ b/book/website/reproducible-research/renv/renv-binder.md
@@ -80,11 +80,6 @@ If R is installed in a Binder, the dropdown menu will show the options to open R
 
 In this section, there are some related terms, which will be outlined here for clarity:
 
-- Binder: A shareable version of a project that can be viewed and interacted within a reproducible computational environment via a web browser.
-- BinderHub: A service which generates Binders. The most widely-used is [mybinder.org](https://mybinder.org), which is maintained by the Binder team. It is possible to create other BinderHubs which can support more specialised configurations. One such configuration could include authentication to enable private repositories to be shared amongst close collaborators.
-- [mybinder.org](https://mybinder.org): A public and free BinderHub. Because it is public you should not use it if your project requires any personal or sensitive information (such as passwords).
-- Binderize: To make a Binder of a project.
-
 - **Binder**: A sharable version of a project that can be viewed and interacted within a reproducible computational environment via a web browser.
 - **BinderHub**: A service which generates Binders. The most widely-used is [mybinder.org](https://mybinder.org), which is maintained by the Binder team. It is possible to create other BinderHubs which can support more specialised configurations. One such configuration could include authentication to enable private repositories to be shared amongst close collaborators.
 - **[mybinder.org](https://mybinder.org)**: A public and free BinderHub. Because it is public, you should not use it if your project requires any personal or sensitive information (such as passwords).


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

Remove duplication of the list under subheading "Disambiguation".

<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent. For example: "Fixes #58", or "Addresses (but does not close) #238". -->

On lines 83-86 there is a duplicate version of the list under the Disambiguation subheading. There is a version where points are bold, and one where they are not. 

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* Remove the unbolded version of the list.

### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [x] N/A


### Acknowledging contributors

<!-- Please select the correct box -->

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file.
- [x] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file: @inwaves
