### PR TITLE
Change master branch references to main or HEAD

### DIFF
--- a/workshops/boost-research-reproducibility-binder/workshop-presentations/zero-to-binder-julia.md
+++ b/workshops/boost-research-reproducibility-binder/workshop-presentations/zero-to-binder-julia.md
@@ -63,8 +63,8 @@ You can create a link to a **live, interactive** version of your code!
 
 1) Create a new repo on GitHub called "my-first-binder".
    - Don't forget to initialise with a README!
-2) Create a file called `hello.jl` via the web interface with `println("Hello from Binder!")` on the first line and commit to master
-3) Create a file called `Project.toml` (:rotating_light: the capitalisation is important!) with the following content and commit it to master.
+2) Create a file called `hello.jl` via the web interface with `println("Hello from Binder!")` on the first line and commit to the `main` branch
+3) Create a file called `Project.toml` (:rotating_light: the capitalisation is important!) with the following content and commit it to `main`.
    This will install Julia into the Binder environment.
 
    ```julia
@@ -82,7 +82,7 @@ You can create a link to a **live, interactive** version of your code!
    > **<https://github.com/your-username/my-first-binder>**
 3) As you type, the webpage generates a link in the "Copy the URL below..." box
    It should look like this:
-   > **<https://mybinder.org/v2/gh/your-username/my-first-binder/master>**
+   > **<https://mybinder.org/v2/gh/your-username/my-first-binder/HEAD>**
 4) Copy it, open a new browser tab and visit that URL.
    - You will see a "spinner" as Binder launches the repo.
 
@@ -121,8 +121,8 @@ It was easy to get started, but our environment is barebones - let's add a **dep
    CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
    ```
 
-3) Check for typos! Then commit to master.
-4) Visit **<https://mybinder.org/v2/gh/your-username/my-first-binder/master>** again in a new tab
+3) Check for typos! Then commit to `main`.
+4) Visit **<https://mybinder.org/v2/gh/your-username/my-first-binder/HEAD>** again in a new tab
 
 This time, click on "Build Logs" in the big, horizontal, grey bar.
 This will let you watch the progress of your build.
@@ -164,7 +164,7 @@ Pushing changes back to the GitHub repo through the container is not possible wi
 
 Binder is all about sharing your work easily and there are two ways to do it:
 
-- Share the **<https://mybinder.org/v2/gh/your-username/my-first-binder/master>** URL directly
+- Share the **<https://mybinder.org/v2/gh/your-username/my-first-binder/HEAD>** URL directly
 
 - Visit **<https://mybinder.org>**, type in the URL of your repo and copy the Markdown or ReStructured Text snippet into your `README.md` file.
   This snippet will render a badge that people can click, which looks like this: ![Binder](https://mybinder.org/badge_logo.svg)
@@ -263,7 +263,7 @@ See this [Software Carpentry lesson](https://swcarpentry.github.io/python-novice
 **JupyterLab** is installed into your containerized repo by default.
 You can access the environment by changing the URL you visit to:
 
-> **<https://mybinder.org/v2/gh/your-username/my-first-binder/master?urlpath=lab>**
+> **<https://mybinder.org/v2/gh/your-username/my-first-binder/HEAD?urlpath=lab>**
 
 **N.B.:** We've already seen how the `?filepath=` argument can link to a specific file in the ["What Binder Provides"](#what-binder-provides) section at the beginning of this workshop.
 

--- a/workshops/boost-research-reproducibility-binder/workshop-presentations/zero-to-binder-python.md
+++ b/workshops/boost-research-reproducibility-binder/workshop-presentations/zero-to-binder-python.md
@@ -68,7 +68,7 @@ You can create a link to a **live, interactive** version of your code!
 1) Create a new repo on GitHub called "my-first-binder".
    - Make sure the repository is **public**, _not private_!
    - Don't forget to initialise with a README!
-2) Create a file called `hello.py` via the web interface with `print("Hello from Binder!")` on the first line and commit to master
+2) Create a file called `hello.py` via the web interface with `print("Hello from Binder!")` on the first line and commit to the `main` branch
 
 ### Why did the repo have to be public?
 
@@ -86,7 +86,7 @@ If accessing private repositories is a feature you/your team need, we advise tha
    > **<https://github.com/your-username/my-first-binder>**
 3) As you type, the webpage generates a link in the "Copy the URL below..." box
    It should look like this:
-   > **<https://mybinder.org/v2/gh/your-username/my-first-binder/master>**
+   > **<https://mybinder.org/v2/gh/your-username/my-first-binder/HEAD>**
 4) Copy it, open a new browser tab and visit that URL.
    - You will see a "spinner" as Binder launches the repo.
 
@@ -119,8 +119,8 @@ It was easy to get started, but our environment is barebones - let's add a **dep
 
 1) In your repo, create a file called `requirements.txt`
 2) Add a line that says: `numpy==1.14.5`
-3) Check for typos! Then commit to master.
-4) Visit **<https://mybinder.org/v2/gh/your-username/my-first-binder/master>** again in a new tab
+3) Check for typos! Then commit to the `main` branch.
+4) Visit **<https://mybinder.org/v2/gh/your-username/my-first-binder/HEAD>** again in a new tab
 
 This time, click on "Build Logs" in the big, horizontal, grey bar.
 This will let you watch the progress of your build.
@@ -173,7 +173,7 @@ Pushing changes back to the GitHub repo through the container is not possible wi
 
 Binder is all about sharing your work easily and there are two ways to do it:
 
-- Share the **<https://mybinder.org/v2/gh/your-username/my-first-binder/master>** URL directly
+- Share the **<https://mybinder.org/v2/gh/your-username/my-first-binder/HEAD>** URL directly
 - Visit **<https://mybinder.org>**, type in the URL of your repo and copy the Markdown or ReStructured Text snippet into your `README.md` file.
   This snippet will render a badge that people can click, which looks like this: ![Binder](https://mybinder.org/badge_logo.svg)
 
@@ -263,7 +263,7 @@ See this [Software Carpentry lesson](https://swcarpentry.github.io/python-novice
 **JupyterLab** is installed into your containerized repo by default.
 You can access the environment by changing the URL you visit to:
 
-> **<https://mybinder.org/v2/gh/your-username/my-first-binder/master?urlpath=lab>**
+> **<https://mybinder.org/v2/gh/your-username/my-first-binder/HEAD?urlpath=lab>**
 
 **N.B.:** We've already seen how the `?filepath=` argument can link to a specific file in the ["What Binder Provides"](#what-binder-provides) section at the beginning of this workshop.
 

--- a/workshops/boost-research-reproducibility-binder/workshop-presentations/zero-to-binder-r.md
+++ b/workshops/boost-research-reproducibility-binder/workshop-presentations/zero-to-binder-r.md
@@ -70,8 +70,8 @@ You can create a link to a **live, interactive** version of your code!
 1) Create a new repo on GitHub called "my-first-binder".
    - Make sure the repository is **public**, _not private_!
    - Don't forget to initialise with a README!
-2) Create a file called `hello.R` via the web interface with `print("Hello from Binder!")` on the first line and commit to master.
-3) Create a file called `runtime.txt` with `r-YYYY-MM-DD` on the first line, where `YYYY-MM-DD` is today's date (eg `r-2020-05-26`). Commit to master.
+2) Create a file called `hello.R` via the web interface with `print("Hello from Binder!")` on the first line and commit to the `main` branch.
+3) Create a file called `runtime.txt` with `r-YYYY-MM-DD` on the first line, where `YYYY-MM-DD` is today's date (eg `r-2020-05-26`). Commit to the `main` branch.
    - _In R you can use `holepunch::write_runtime()` to create a `runtime.txt` in the `.binder/` directory, configured with today's date._
 
 ### Why did the repo have to be public?
@@ -91,7 +91,7 @@ If accessing private repositories is a feature you/your team need, we advise tha
 
 3) As you type, the webpage generates a link in the "Copy the URL below..." box
    It should look like this:
-   > **<https://mybinder.org/v2/gh/your-username/my-first-binder/master>**
+   > **<https://mybinder.org/v2/gh/your-username/my-first-binder/HEAD>**
 
 4) Copy it, open a new browser tab and visit that URL.
    - You will see a "spinner" as Binder launches the repo.
@@ -126,8 +126,8 @@ It was easy to get started, but our environment is barebones - let's add a **dep
 1) In your repo, create a file called `install.R`
 2) Add a line that says: `install.packages("readr")`
    - _In R you can create an `install.R` file and automatically add the code to install all dependencies in your project using `holepunch::write_install()`._
-3) Check for typos! Then commit to master.
-4) Visit **<https://mybinder.org/v2/gh/your-username/my-first-binder/master>** again in a new tab
+3) Check for typos! Then commit to the `main` branch.
+4) Visit **<https://mybinder.org/v2/gh/your-username/my-first-binder/HEAD>** again in a new tab
 
 This time, click on "Build Logs" in the big, horizontal, grey bar.
 This will let you watch the progress of your build.
@@ -173,7 +173,7 @@ Pushing changes back to the GitHub repo through the container is not possible wi
 
 Binder is all about sharing your work easily and there are two ways to do it:
 
-- Share the **<https://mybinder.org/v2/gh/your-username/my-first-binder/master>** URL directly
+- Share the **<https://mybinder.org/v2/gh/your-username/my-first-binder/HEAD>** URL directly
 - Visit **<https://mybinder.org>**, type in the URL of your repo and copy the Markdown or ReStructured Text snippet into your `README.md` file.
   This snippet will render a badge that people can click, which looks like this: ![Binder](https://mybinder.org/badge_logo.svg)
 
@@ -272,7 +272,7 @@ See this [Software Carpentry lesson](https://swcarpentry.github.io/python-novice
 **JupyterLab** is installed into your containerized repo by default.
 You can access the environment by changing the URL you visit to:
 
-> **<https://mybinder.org/v2/gh/your-username/my-first-binder/master?urlpath=lab>**
+> **<https://mybinder.org/v2/gh/your-username/my-first-binder/HEAD?urlpath=lab>**
 
 **N.B.:** We've already seen how the `?filepath=` argument can link to a specific file in the ["What Binder Provides"](#what-binder-provides) section at the beginning of this workshop.
 

--- a/workshops/boost-research-reproducibility-binder/workshop-presentations/zero-to-binder-solo.md
+++ b/workshops/boost-research-reproducibility-binder/workshop-presentations/zero-to-binder-solo.md
@@ -67,7 +67,7 @@ You can create a link to a **live, interactive** version of your code!
 1) Create a new repo on GitHub called "my-first-binder".
    - Make sure the repository is **public**, _not private_!
    - Don't forget to initialise with a README!
-2) Create a file called `hello.py` via the web interface with `print("Hello from Binder!")` on the first line and commit to master
+2) Create a file called `hello.py` via the web interface with `print("Hello from Binder!")` on the first line and commit to the `main` branch
 
 **N.B.:** GitHub repos **must** be _public_ in order to work with Binder.
 
@@ -86,7 +86,7 @@ You can create a link to a **live, interactive** version of your code!
    > **<https://github.com/your-username/my-first-binder>**
 3) As you type, the webpage generates a link in the "Copy the URL below..." box
    It should look like this:
-   > **<https://mybinder.org/v2/gh/your-username/my-first-binder/master>**
+   > **<https://mybinder.org/v2/gh/your-username/my-first-binder/HEAD>**
 4) Copy it, open a new browser tab and visit that URL.
    - You will see a "spinner" as Binder launches the repo.
 
@@ -129,8 +129,8 @@ It was easy to get started, but our environment is barebones - let's add a **dep
 
 1) In your repo, create a file called `requirements.txt`
 2) Add a line that says: `numpy==1.14.5`
-3) Check for typos! Then commit to master.
-4) Visit **<https://mybinder.org/v2/gh/your-username/my-first-binder/master>** again in a new tab
+3) Check for typos! Then commit to `main`.
+4) Visit **<https://mybinder.org/v2/gh/your-username/my-first-binder/HEAD>** again in a new tab
 
 This time, click on "Build Logs" in the big, horizontal, grey bar.
 This will let you watch the progress of your build.
@@ -193,7 +193,7 @@ Pushing changes back to the GitHub repo through the container is not possible wi
 
 Binder is all about sharing your work easily and there are two ways to do it:
 
-- Share the **<https://mybinder.org/v2/gh/your-username/my-first-binder/master>** URL directly
+- Share the **<https://mybinder.org/v2/gh/your-username/my-first-binder/HEAD>** URL directly
 - Visit **<https://mybinder.org>**, type in the URL of your repo and copy the Markdown or ReStructured Text snippet into your `README.md` file.
   This snippet will render a badge that people can click, which looks like this: ![Binder](https://mybinder.org/badge_logo.svg)
 
@@ -297,7 +297,7 @@ See this [Software Carpentry lesson](https://swcarpentry.github.io/python-novice
 **JupyterLab** is installed into your containerized repo by default.
 You can access the environment by changing the URL you visit to:
 
-> **<https://mybinder.org/v2/gh/your-username/my-first-binder/master?urlpath=lab>**
+> **<https://mybinder.org/v2/gh/your-username/my-first-binder/HEAD?urlpath=lab>**
 
 **N.B.:** We've already seen how the `?filepath=` argument can link to a specific file in the ["What Binder Provides"](#what-binder-provides) section at the beginning of this workshop.
 


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent. For example: "Fixes #58", or "Addresses (but does not close) #238". -->

This PR changes `master` branch references in the Zero to Binder tutorials to `main` or `HEAD`.

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* The Zero to Binder tutorial files (in all language flavours)


### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [ ] Everything looks ok?


### Acknowledging contributors

<!-- Please select the correct box -->

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
