### PR TITLE
Fix link in table of contents

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -11,7 +11,7 @@ To make clear what is expected, we ask all members of the community to conform t
 
 * [1 Introduction](#1-introduction)
 * [2 Code of Conduct](#2-code-of-conduct)
-  * [2.1 Expected Behaviour](21-expected-behaviours)
+  * [2.1 Expected Behaviour](#21-expected-behaviour)
   * [2.2 Unacceptable Behaviour](#22-unacceptable-behaviour)
   * [2.3 Consequences of Unacceptable Behaviour](#23-consequences-of-unacceptable-behaviour)
   * [2.4 Feedback](#24-feedback)


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent. For example: "Fixes #58", or "Addresses (but does not close) #238". -->

This PR fixes a broken link in the code of conduct's table of contents.

I have also checked that all other links in the code of conduct work.

PS I didn't open an issue because I felt the change was so small it didn't merit one. I couldn't see and existing issue or PR for this problem. Do say if that causes problems for you.

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
-  Fix broken link to expected behaviours section in the code of conduct's table of contents


### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [ ] Everything looks ok?


### Acknowledging contributors

<!-- Please select the correct box -->

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->