### PR TITLE
Update _figure-list.md - add scientific union badge to the list 

### DIFF
--- a/book/website/figures/_figure-list.md
+++ b/book/website/figures/_figure-list.md
@@ -33,7 +33,8 @@
 | regents_map                | BinderHub workshop        | Map to workshop location                          |
 | reproducibility_kirstie    |                           | Depicts cow code and data relate to good practise |
 | ResearchCompendium         | Research Compendium       | Illustration on research compendium               |
-| risk_matrix                | risk_assessment
+| risk_matrix                | risk_assessment           |                                                   |
+| scientificunionbadge       | Ethical Research          | Image of an enamel badge                          |
 | sub_branch                 | Version control           | Illustrates version control branch + sub branch   |
 | testing_motivation_1       | Testing                   | Example of consequence of not testing code        |
 | testing_motivation_2       | Testing                   | Example of consequence of not testing code        |


### PR DESCRIPTION
Updating to add the scientific union badge image to the list


### Summary

Hopefully this fixes the error with images in the Activism chapter! 

### List of changes proposed in this PR (pull-request)

add scientific union badge to the list of figures

### What should a reviewer concentrate their feedback on?

- [ ] Everything looks ok?


### Acknowledging contributors

<!-- Please select the correct box -->

- [X ] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
