### PR TITLE
Compress two blockquotes into one

### DIFF
--- a/book/website/reproducible-research/renv/renv-containers.md
+++ b/book/website/reproducible-research/renv/renv-containers.md
@@ -409,9 +409,7 @@ If, when deleting a container, a `-v` is included after `rm` in `sudo docker rm 
 ## Singularity
 
 
-> **Prerequisites**: At present, Singularity only runs on Linux systems (for example Ubuntu). If you use, macOS,
-
-> [Singularity Desktop for macOS](https://www.sylabs.io/singularity-desktop-macos/) is in "Alpha Preview" stage.
+> **Prerequisites**: At present, Singularity only runs on Linux systems (for example Ubuntu). If you use macOS, [Singularity Desktop for macOS](https://www.sylabs.io/singularity-desktop-macos/) is in "Beta" release stage.
 
 A significant drawback of using Docker for reproducible research is that it is not intended as a user-space application but as a tool for server administrators. 
 As such, it requires root access to operate. 


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent. For example: "Fixes #58", or "Addresses (but does not close) #238". -->

* On lines 412 and 413, we have two separate blockquotes for the Singularity prerequisites note. I think this would look better compressed into one blockquote. Also, Singularity Desktop for macOS is now in Beta stage, I think that could also be changed.

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* Compress two blockquotes into one
* Update "alpha preview" to "beta" for the Singularity macOS Desktop app.


### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [ ] Changes match style guide?


### Acknowledging contributors

<!-- Please select the correct box -->

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
