### PR TITLE
Fix example label directive to have ")=" at the end

### DIFF
--- a/book/website/community-handbook/style/style-crossref.md
+++ b/book/website/community-handbook/style/style-crossref.md
@@ -55,7 +55,7 @@ For example, in the guide `Reproducible Research`, we have a chapter called `Ove
 We have created a label for that chapter called `rr-overview` by adding the label on the top of the header by using the following directive
 
 ```
-(rr-overview=)
+(rr-overview)=
 # Overview
 ```
 


### PR DESCRIPTION


<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent. For example: "Fixes #58", or "Addresses (but does not close) #238". -->

The example label directive on line 58, "(rr-overview=)" should have the equals sign on the outside of the parentheses.

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* Update label directive

### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [ ] Everything looks ok?


### Acknowledging contributors

<!-- Please select the correct box -->

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
