### PR TITLE
Remove R example from paired examples for workshop

### DIFF
--- a/workshops/boost-research-reproducibility-binder/paired_examples.md
+++ b/workshops/boost-research-reproducibility-binder/paired_examples.md
@@ -21,9 +21,10 @@ In the examples with branches (2, 3 and 4) we ask you to see the difference betw
 * https://github.com/alan-turing-institute/CompEnv-Ex3
   * Uses Jupyter Notebooks.
     This one is really quite hard...don't try this one first!
-* https://github.com/alan-turing-institute/CompEnv-Ex4
-  * Uses RStudio.
-    Great if you're an R user, a little idiosyncratic if you don't use R regularly.
+* 🙅‍♀️ ~~https://github.com/alan-turing-institute/CompEnv-Ex4~~ 🙅‍♀️
+  * ~~Uses RStudio.~~
+    ~~Great if you're an R user, a little idiosyncratic if you don't use R regularly.~~
+  * Unfortunately, this example no longer works due to upgrades on mybinder.org.
 
 ***Please ask if you have any questions.***
 This section is to allow you to explore the examples and learn by doing.


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent. For example: "Fixes #58", or "Addresses (but does not close) #238". -->

The paired example for the (Boost your research reproducibility
workshop) that uses R no longer works/builds on mybinder.org due to
upgrades to repo2docker. We note this in the markdown file listing the
paired examples.

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* `workshops/boost-research-reproducibility-binder/paired_examples.md` edited

### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [ ] Everything looks ok?

### Acknowledging contributors

<!-- Please select the correct box -->

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
