### PR TITLE
Update link to reflect renaming of Riot to Element

### DIFF
--- a/book/website/collaboration/new-community/new-community-guide.md
+++ b/book/website/collaboration/new-community/new-community-guide.md
@@ -18,7 +18,7 @@ While reading this chapter, please be aware that you may need to make adjustment
 ### 1. Choose a communication platform
 
 - When leading an open project, use collaborative and open platforms such as [GitHub](http://github.com/) or [GitLab](https://about.gitlab.com/).
-- Evaluate the need for any real-time communications, such as if a text chat system like [Slack](https://slack.com) or [Riot/Matrix](https://about.riot.im/free) will be useful or if a mailing list will be sufficient (read details {ref}`Communication Channels <cm-os-comms-channels>`).
+- Evaluate the need for any real-time communications, such as if a text chat system like [Slack](https://slack.com) or [Element/Matrix](https://element.io/get-started) will be useful or if a mailing list will be sufficient (read details {ref}`Communication Channels <cm-os-comms-channels>`).
   - Consider a separate internal communication platform for your community members and an external one for showing what you’ve done to the rest of the world.
 - A [Twitter account](https://twitter.com) or a simple website (such as on [GitHub pages](https://pages.github.com/)) can be useful external platforms.
 - Make sure that the choices of these platforms are made to ensure that there is a low barrier to join them.


### PR DESCRIPTION
The reference Matrix client Riot was renamed recently to Element, and the website address changed too. This minor tweak updates the new community guide to reflect that.

### What should a reviewer concentrate their feedback on?

- [ ] Did I choose the correct link


### Acknowledging contributors

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file.