### PR TITLE
Adding link to open research image

### DIFF
--- a/book/website/reproducible-research/open.md
+++ b/book/website/reproducible-research/open.md
@@ -8,6 +8,15 @@
 | -------------|----------|------|
 | {ref}`rr-vcs` | Helpful | Experience with GitHub is particularly useful |
 
+
+```{figure} ../figures/EvolutionOpenResearch.jpg
+---
+name: EvolutionOpenResearch
+alt: This image shows a researcher evolving their research practices to move towards the era of open research. 
+---
+_The Turing Way_ project illustration by Scriberia. Original version on Zenodo. http://doi.org/10.5281/zenodo.3695300. ```
+
+
 (rr-open-summary)=
 ## Summary
 


### PR DESCRIPTION
Adding open research image


Fixes #<NUM>
Adding open research image

adding link to image in md file
adding alt text

### List of changes proposed in this PR (pull-request)

- [x] adding link to image in md file
- [x] adding alt text
- [x] checking it has rendered properly


### What should a reviewer concentrate their feedback on?

- [ ] Everything looks ok?


### Acknowledging contributors

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
