### PR TITLE
Adding an image in the Open Data page

### DIFF
--- a/book/website/_toc.yml
+++ b/book/website/_toc.yml
@@ -475,6 +475,6 @@
   - title: Bibliography
     file: afterword/bibliography
   - title: Contributors Record
-    file: afterword/contributors-record]
+    file: afterword/contributors-record
   - title: Legal Disclaimer
     file: afterword/legal-disclaimer

--- a/book/website/reproducible-research/open/open-data.md
+++ b/book/website/reproducible-research/open/open-data.md
@@ -44,7 +44,7 @@ height: 500px
 name: data-privacy
 alt: The image contains points about why private data may be used.
 ---
-_The Turing Way_ project illustration by Scriberia. Original version on Zenodo. http://doi.org/10.5281/zenodo.3695300
+_The Turing Way_ project illustration by Scriberia. Original version on Zenodo. [http://doi.org/10.5281/zenodo.3695300](http://doi.org/10.5281/zenodo.3695300)
 ```
 
 (rr-open-data-barriers-privacy)=

--- a/book/website/reproducible-research/open/open-data.md
+++ b/book/website/reproducible-research/open/open-data.md
@@ -38,6 +38,15 @@ These are cultural challenges that might be addressed in changing practice going
 However, there are also legal, ethical or contractual reasons that sometimes prevent making data publicly available in its entirety or even in parts.
 Below, we discuss some reasons explaining why this may be the case.
 
+```{figure} ../../figures/data-privacy.jpg
+---
+height: 500px
+name: data-privacy
+alt: The image contains points about why private data may be used.
+---
+_The Turing Way_ project illustration by Scriberia. Original version on Zenodo. http://doi.org/10.5281/zenodo.3695300
+```
+
 (rr-open-data-barriers-privacy)=
 ### Privacy And Data Protection
 

--- a/book/website/reproducible-research/open/open-data.md
+++ b/book/website/reproducible-research/open/open-data.md
@@ -42,7 +42,7 @@ Below, we discuss some reasons explaining why this may be the case.
 ---
 height: 500px
 name: data-privacy
-alt: The image contains points about why private data may be used.
+alt: An image detailing why private data should be used. A person stands next to a well with 'private data' written on it and a padlock around it. It is black and white and blue. The text lists that 'people deserve: dignity, agency, privacy, rights, confirmed consent.'
 ---
 _The Turing Way_ project illustration by Scriberia. Original version on Zenodo. [http://doi.org/10.5281/zenodo.3695300](http://doi.org/10.5281/zenodo.3695300)
 ```
@@ -93,4 +93,3 @@ If a company spends time and money developing something new, the details of whic
 The result is that no one would innovate in the first place.
 Similarly, for public safety concerns, governments are often unwilling to publish data that relates to issues such as national security.
 In such cases, it may not be possible to make data open, or it may only be possible to share partial/obscured datasets.
-


### PR DESCRIPTION
### Summary

Adding data-privacy image in the Open Data page.

Fixes #1881

### List of changes proposed in this PR (pull-request)

* Adding an image.

### What should a reviewer concentrate their feedback on?

- [ ] The image is placed correctly.
- [ ] Everything looks ok?

### Acknowledging contributors

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
