### PR TITLE
Fix: CI latin check should ignore binary images

### DIFF
--- a/tests/no-bad-latin.py
+++ b/tests/no-bad-latin.py
@@ -5,7 +5,7 @@ from pull_files import filter_files
 
 HERE = os.getcwd()
 ABSOLUTE_HERE = os.path.dirname(HERE)
-IGNORE_LIST = [ "_config.yml", "style.md", "contributors-record.md"]
+IGNORE_LIST = ["config.yml", "style.md", "contributors-record.md"]
 
 
 def parse_args():
@@ -24,44 +24,47 @@ def parse_args():
 
 
 def remove_comments(text_string):
-    """Function to omit  html comment identifiers in a text string using
-	regular expression matches
+    """
+    Function to omit  html comment identifiers in a text string using
+    regular expression matches.
 
-	Arguments:
-		text_string {string} -- The text to be matched
+    Arguments:
+        text_string {string} -- The text to be matched
 
-	Returns:
-		{string} -- The input text string with html comments removed
-	"""
+    Returns:
+        {string} -- The input text string with html comments removed
+    """
     p = re.sub("(?s)<!--(.*?)-->", "", text_string)
     return p
 
 
 def get_lines(text_string, sub_string):
-    """Get individual lines in a text file
+    """
+    Get individual lines in a text file.
 
-	Arguments:
-		text_string {string} -- The text string to test
-		sub_string {string} -- The conditional string to perform splitting on
+    Arguments:
+        text_string {string} -- The text string to test
+        sub_string {string} -- The conditional string to perform splitting on
 
-	Returns:
-		{list} -- A list of split strings
-	"""
+    Returns:
+        {list} -- A list of split strings
+    """
     lines = [line for line in text_string.split("\n") if sub_string in line]
     return lines
 
 
 def construct_error_message(files_dict):
-    """Function to construct an error message pointing out where bad latin
-	phrases appear in lines of text
+    """
+    Function to construct an error message pointing out where bad latin
+    phrases appear in lines of text.
 
-	Arguments:
-		files_dict {dictionary} -- Dictionary of failing files containing the
-		                           bad latin phrases and offending lines
+    Arguments:
+        files_dict {dictionary} -- Dictionary of failing files containing
+                                   bad latin phrases and offending lines
 
-	Returns:
-		{string} -- The error message to be raised
-	"""
+    Returns:
+{string} -- The error message to be raised
+    """
     error_message = ["Bad latin found in the following files:\n"]
 
     for file in files_dict.keys():
@@ -73,18 +76,18 @@ def construct_error_message(files_dict):
 
 
 def read_and_check_files(files):
-    """Function to read in files, remove html comments and check for bad latin
-	phrases
+    """
+    Function to read in files, remove html comments and check for bad latin phrases.
 
-	Arguments:
-		files {list} -- List of filenames to be checked
+    Arguments:
+        files {list} -- List of filenames to be checked
 
-	Returns:
-		{dict} -- Dictionary: Top level keys are absolute filepaths to files
-		          that failed the check. Each of these has two keys:
-				  'latin_type' containing the unwanted latin phrase, and 'line'
-				  containing the offending line.
-	"""
+    Returns:
+        {dict} -- Dictionary: Top level keys are absolute filepaths to files
+                  that failed the check. Each of these has two keys:
+                  'latin_type' containing the unwanted latin phrase, and 'line'
+                  containing the offending line.
+    """
     failing_files = {}
     bad_latin = ["i.e.", "e.g.", "e.t.c.", " etc", " ie ", "et cetera"]
 
@@ -114,14 +117,15 @@ def read_and_check_files(files):
 
 
 def get_all_files(directory=os.path.join(ABSOLUTE_HERE, "book", "website")):
-    """Get a list of files to be checked. Ignores image files.
+    """
+    Get a list of files to be checked. Ignores image files.
 
-	Keyword Arguments:
-		directory {string} -- The directory containing the files to check
+    Keyword Arguments:
+        directory {string} -- The directory containing the files to check
 
-	Returns:
-		{list} -- List of files to check
-	"""
+    Returns:
+        {list} -- List of files to check
+    """
     files = []
     filetypes_to_ignore = (".png", ".jpg")
 

--- a/tests/no-bad-latin.py
+++ b/tests/no-bad-latin.py
@@ -138,7 +138,7 @@ def main():
     args = parse_args()
 
     if args.pull_request is not None:
-        files = filter_files(args.pull_request)
+        files = filter_files(args.pull_request, ignore_suffix=('.jpg', '.png'))
     else:
         files = get_all_files()
 

--- a/tests/pull_files.py
+++ b/tests/pull_files.py
@@ -63,7 +63,7 @@ def filter_files(pr_num, start_phrase="book/website", ignore_suffix=None):
         ignore_suffix = ()
 
     for filename in files:
-        if filename.startswith(start_phrase) and filename.endswith(ignore_suffix):
+        if filename.startswith(start_phrase) and not filename.endswith(ignore_suffix):
             filtered_files.append(filename)
 
     return filtered_files

--- a/tests/pull_files.py
+++ b/tests/pull_files.py
@@ -40,7 +40,7 @@ def get_files_from_pr(pr_num):
     return files
 
 
-def filter_files(pr_num, start_phrase="book/website"):
+def filter_files(pr_num, start_phrase="book/website", ignore_suffix=None):
     """Filter modified files from a Pull Request by a start phrase
 
     Arguments:
@@ -50,14 +50,20 @@ def filter_files(pr_num, start_phrase="book/website"):
         start_phrase {str} -- Start phrase to filter changed files by
                               (default: {"book/website"})
 
+        ignore_suffix {str} -- File suffix or tuple of suffixes to ignore.
+
+
     Returns:
         {list} -- List of filenames that begin with the desired start phrase
     """
     files = get_files_from_pr(pr_num)
     filtered_files = []
 
+    if ignore_suffix is None:
+        ignore_suffix = ()
+
     for filename in files:
-        if filename.startswith(start_phrase):
+        if filename.startswith(start_phrase) and filename.endswith(ignore_suffix):
             filtered_files.append(filename)
 
     return filtered_files


### PR DESCRIPTION
We see a latin check failure with a matching pattern in one of the new images added in #1588 

This PR fixes the CI scripts to ignore those files. Locally however I could not reproduce the match with that image file (I assume the encoding might work differently than in the VM), so first I pull the whole pull request. If CI is all green I'll remove all unrelated commits to keep the infrastructure changes only.
