### PR TITLE
Updating the landing page

### DIFF
--- a/book/website/welcome.md
+++ b/book/website/welcome.md
@@ -1,14 +1,11 @@
 (welcome)=
 # Welcome
 
-_The Turing Way_ is an open source community-driven guide to reproducible, ethical, inclusive and collaborative data science.
+_The Turing Way_ is an open-source community-driven guide to reproducible, ethical, inclusive and collaborative data science.
 
-Our goal is to provide all the information that data scientists in academia, industry, government and the third sector need at the start of their projects to ensure that they are easy to reproduce and reuse at the end.
+Our goal is to provide all the information that data scientists in academia, industry, government and the third sector need to ensure that the projects they work on are easy to reproduce and reuse.
 
-The book started as a guide for reproducibility, covering version control, testing, and continuous integration.
-However, technical skills are just one aspect of making data science research "open for all".
-
-In February 2020, _The Turing Way_ expanded to a series of books covering reproducible research, project design, communication, collaboration, and ethical research.
+Do not try to read the guide from start to finish. Take a [buffet approach](https://mobile.twitter.com/rossdavism/status/1138441421143400453) instead: browse the chapters or [search](https://the-turing-way.netlify.app/search.html) for something you would like to learn about.
 
 ```{figure} figures/welcome.jpg
 ---
@@ -60,6 +57,14 @@ Accordingly, everyone who participates in _The Turing Way_ project is expected t
 All contributions must abide by our [code of conduct](https://github.com/alan-turing-institute/the-turing-way/blob/master/CODE_OF_CONDUCT.md).
 
 ![Gif showing screen capture of contributors table, smiling faces and emojis representing the types of contributions in a table](https://media.giphy.com/media/gKIUisnjpj2PS75nOJ/giphy.gif)
+
+(welcome-history)=
+## History
+
+The book started as a guide for reproducibility, covering version control, testing, and continuous integration.
+However, technical skills are just one aspect of making data science research "open for all".
+
+In February 2020, _The Turing Way_ expanded to a series of books covering reproducible research, project design, communication, collaboration, and ethical research.
 
 (welcome-citing)=
 ## Citing _The Turing Way_

--- a/book/website/welcome.md
+++ b/book/website/welcome.md
@@ -7,12 +7,12 @@ Our goal is to provide all the information that data scientists in academia, ind
 
 Warning: Do not try to read the _The Turing Way_ from start to finish. Take a [buffet approach](https://mobile.twitter.com/rossdavism/status/1138441421143400453). Browse the different guides that make up the book, or use the search box to search for whatever you would like to learn about first.
 
-```{figure} figures/TheTuringWayChapters.jpg
+```{figure} figures/welcome.jpg
 ---
-name: TheTuringWayChapters
-alt: The Turing Way Guide to reproducible research and it's stucture illustrated to show a set of doors to represent how it's built on chapters and sub chapters of the different areas of the guide
+name: welcome-image
+alt: The Turing Way project is illustrated as a road or path with shops for different data science skills. People can go in and out with their shopping cart and pick and choose what they need.
 ---
-_The Turing Way_ project illustration by Scriberia. Original version on Zenodo. http://doi.org/10.5281/zenodo.3695300.
+_The Turing Way_ project illustration by Scriberia. Zenodo. [http://doi.org/10.5281/zenodo.3332807](http://doi.org/10.5281/zenodo.3332807)
 ```
 
 (welcome-community)=
@@ -37,12 +37,12 @@ To join this community, please read our [contribution guidelines](https://github
 More information about the community and the project is available in the {ref}`ch`.
 We look forward to expanding and building _The Turing Way_ together.
 
-```{figure} figures/welcome.jpg
+```{figure} figures/theturingway-chapters.jpg
 ---
-name: welcome-image
-alt: The Turing Way project is illustrated as a road or path with shops for different data science skills. People can go in and out with their shopping cart and pick and choose what they need.
+name: theturingway-chapters
+alt: The Turing Way Guide to reproducible research and it's stucture illustrated to show a set of doors to represent how it's built on chapters and sub chapters of the different areas of the guide
 ---
-_The Turing Way_ project illustration by Scriberia. Zenodo. [http://doi.org/10.5281/zenodo.3332807](http://doi.org/10.5281/zenodo.3332807)
+_The Turing Way_ project illustration by Scriberia. Original version on Zenodo. http://doi.org/10.5281/zenodo.3695300.
 ```
 
 Although _The Turing Way_ receives support and funding from [The Alan Turing Institute](https://www.turing.ac.uk/), the project is designed to be a global collaboration.

--- a/book/website/welcome.md
+++ b/book/website/welcome.md
@@ -3,7 +3,7 @@
 
 _The Turing Way_ is a handbook to reproducible, ethical, inclusive and collaborative data science. 
 
-The project is open source (anyone can [inspect the code](https://github.com/alan-turing-institute/the-turing-way), open contribution (anyone can {ref}`contribute<ch-contributing>`), and open-licenced (anyone can [re-use the materials](https://github.com/alan-turing-institute/the-turing-way/blob/master/LICENSE.md)).
+The project is open source (anyone can [inspect the code](https://github.com/alan-turing-institute/the-turing-way)), open contribution (anyone can {ref}`contribute<ch-contributing>`), and open-licenced (anyone can [re-use the materials](https://github.com/alan-turing-institute/the-turing-way/blob/master/LICENSE.md)).
 
 Our goal is to provide all the information that data scientists in academia, industry, government and the third sector need to ensure that the projects they work on are easy to reproduce and reuse.
 

--- a/book/website/welcome.md
+++ b/book/website/welcome.md
@@ -5,7 +5,7 @@ _The Turing Way_ is an open-source community-driven guide to reproducible, ethic
 
 Our goal is to provide all the information that data scientists in academia, industry, government and the third sector need to ensure that the projects they work on are easy to reproduce and reuse.
 
-Do not try to read the guide from start to finish. Take a [buffet approach](https://mobile.twitter.com/rossdavism/status/1138441421143400453) instead: browse the chapters or [search](https://the-turing-way.netlify.app/search.html) for something you would like to learn about.
+Warning: Do not try to read the guide from start to finish. Take a [buffet approach](https://mobile.twitter.com/rossdavism/status/1138441421143400453). Browse the chapters, or use the search box to search for whatever you would like to learn about first.
 
 ```{figure} figures/welcome.jpg
 ---
@@ -61,10 +61,7 @@ All contributions must abide by our [code of conduct](https://github.com/alan-tu
 (welcome-history)=
 ## History
 
-The book started as a guide for reproducibility, covering version control, testing, and continuous integration.
-However, technical skills are just one aspect of making data science research "open for all".
-
-In February 2020, _The Turing Way_ expanded to a series of books covering reproducible research, project design, communication, collaboration, and ethical research.
+The book started in January 2019 as a guide for reproducibility, covering {ref}`rr-vcs`, {ref}`rr-testing`, and {ref}`rr-ci`. However, technical skills are just one aspect of making data science research "open for all" and so in February 2020, _The Turing Way_ expanded into a series of books covering {ref}`rr`, {ref}`pd`, {ref}`cm`, {ref}`cl`, and {ref}`er`.
 
 (welcome-citing)=
 ## Citing _The Turing Way_

--- a/book/website/welcome.md
+++ b/book/website/welcome.md
@@ -1,18 +1,18 @@
 (welcome)=
 # Welcome
 
-_The Turing Way_ is an open-source community-driven guide to reproducible, ethical, inclusive and collaborative data science.
+_The Turing Way_ is an open-source community-driven book about how to do reproducible, ethical, inclusive and collaborative data science.
 
 Our goal is to provide all the information that data scientists in academia, industry, government and the third sector need to ensure that the projects they work on are easy to reproduce and reuse.
 
-Warning: Do not try to read the guide from start to finish. Take a [buffet approach](https://mobile.twitter.com/rossdavism/status/1138441421143400453). Browse the chapters, or use the search box to search for whatever you would like to learn about first.
+Warning: Do not try to read the _The Turing Way_ from start to finish. Take a [buffet approach](https://mobile.twitter.com/rossdavism/status/1138441421143400453). Browse the different guides that make up the book, or use the search box to search for whatever you would like to learn about first.
 
-```{figure} figures/welcome.jpg
+```{figure} figures/TheTuringWayChapters.jpg
 ---
-name: welcome-image
-alt: The Turing Way project is illustrated as a road or path with shops for different data science skills. People can go in and out with their shopping cart and pick and choose what they need.
+name: TheTuringWayChapters
+alt: The Turing Way Guide to reproducible research and it's stucture illustrated to show a set of doors to represent how it's built on chapters and sub chapters of the different areas of the guide
 ---
-_The Turing Way_ project illustration by Scriberia. Zenodo. [http://doi.org/10.5281/zenodo.3332807](http://doi.org/10.5281/zenodo.3332807)
+_The Turing Way_ project illustration by Scriberia. Original version on Zenodo. http://doi.org/10.5281/zenodo.3695300.
 ```
 
 (welcome-community)=
@@ -34,18 +34,16 @@ Please use and re-use whatever you need, for any purpose.
 The book is collaboratively written and open from the start.
 To make this project truly accessible and useful for everyone, we invite you to contribute your skills and bring your perspectives into this project.
 To join this community, please read our [contribution guidelines](https://github.com/alan-turing-institute/the-turing-way/blob/master/CONTRIBUTING.md) and ways to [get in touch](https://github.com/alan-turing-institute/the-turing-way#get-in-touch).
-More information about the community and the project is available in the [Community Handbook](./community-handbook/community-handbook).
+More information about the community and the project is available in the {ref}`ch`.
 We look forward to expanding and building _The Turing Way_ together.
 
-
-```{figure} figures/TheTuringWayChapters.jpg
+```{figure} figures/welcome.jpg
 ---
-name: TheTuringWayChapters
-alt: The Turing Way Guide to reproducible research and it's stucture illustrated to show a set of doors to represent how it's built on chapters and sub chapters of the different areas of the guide
+name: welcome-image
+alt: The Turing Way project is illustrated as a road or path with shops for different data science skills. People can go in and out with their shopping cart and pick and choose what they need.
 ---
-_The Turing Way_ project illustration by Scriberia. Original version on Zenodo. http://doi.org/10.5281/zenodo.3695300.
+_The Turing Way_ project illustration by Scriberia. Zenodo. [http://doi.org/10.5281/zenodo.3332807](http://doi.org/10.5281/zenodo.3332807)
 ```
-
 
 Although _The Turing Way_ receives support and funding from [The Alan Turing Institute](https://www.turing.ac.uk/), the project is designed to be a global collaboration.
 We have contributions from across the UK, and from India, Mexico, Australia, USA, and many European countries.
@@ -61,7 +59,7 @@ All contributions must abide by our [code of conduct](https://github.com/alan-tu
 (welcome-history)=
 ## History
 
-The book started in January 2019 as a guide for reproducibility, covering {ref}`rr-vcs`, {ref}`rr-testing`, and {ref}`rr-ci`. However, technical skills are just one aspect of making data science research "open for all" and so in February 2020, _The Turing Way_ expanded into a series of books: {ref}`rr`, {ref}`pd`, {ref}`cm`, {ref}`cl`, and {ref}`er`.
+The book started in January 2019 as a guide for reproducibility, covering {ref}`rr-vcs`, {ref}`rr-testing`, and {ref}`rr-ci`. However, technical skills are just one aspect of making data science research "open for all" and so in February 2020, _The Turing Way_ expanded into a series of guides: {ref}`rr`, {ref}`pd`, {ref}`cm`, {ref}`cl`, and {ref}`er`.
 
 (welcome-citing)=
 ## Citing _The Turing Way_

--- a/book/website/welcome.md
+++ b/book/website/welcome.md
@@ -1,7 +1,7 @@
 (welcome)=
 # Welcome
 
-_The Turing Way_ is a handbook to reproducible, ethical, inclusive and collaborative data science. 
+_The Turing Way_ is a handbook to reproducible, ethical and collaborative data science. 
 
 The project is open source (anyone can [inspect the code](https://github.com/alan-turing-institute/the-turing-way)), open contribution (anyone can {ref}`contribute<ch-contributing>`), and open licenced (anyone can [re-use the materials](https://github.com/alan-turing-institute/the-turing-way/blob/master/LICENSE.md)).
 

--- a/book/website/welcome.md
+++ b/book/website/welcome.md
@@ -1,7 +1,9 @@
 (welcome)=
 # Welcome
 
-_The Turing Way_ is an open-source community-driven book about how to do reproducible, ethical, inclusive and collaborative data science.
+_The Turing Way_ is a handbook to reproducible, ethical, inclusive and collaborative data science. 
+
+The project is open source (anyone can [inspect the code](https://github.com/alan-turing-institute/the-turing-way), open contribution (anyone can {ref}`contribute<ch-contributing>`), and open-licenced (anyone can [re-use the materials](https://github.com/alan-turing-institute/the-turing-way/blob/master/LICENSE.md)).
 
 Our goal is to provide all the information that data scientists in academia, industry, government and the third sector need to ensure that the projects they work on are easy to reproduce and reuse.
 

--- a/book/website/welcome.md
+++ b/book/website/welcome.md
@@ -61,7 +61,7 @@ All contributions must abide by our [code of conduct](https://github.com/alan-tu
 (welcome-history)=
 ## History
 
-The book started in January 2019 as a guide for reproducibility, covering {ref}`rr-vcs`, {ref}`rr-testing`, and {ref}`rr-ci`. However, technical skills are just one aspect of making data science research "open for all" and so in February 2020, _The Turing Way_ expanded into a series of books covering {ref}`rr`, {ref}`pd`, {ref}`cm`, {ref}`cl`, and {ref}`er`.
+The book started in January 2019 as a guide for reproducibility, covering {ref}`rr-vcs`, {ref}`rr-testing`, and {ref}`rr-ci`. However, technical skills are just one aspect of making data science research "open for all" and so in February 2020, _The Turing Way_ expanded into a series of books: {ref}`rr`, {ref}`pd`, {ref}`cm`, {ref}`cl`, and {ref}`er`.
 
 (welcome-citing)=
 ## Citing _The Turing Way_

--- a/book/website/welcome.md
+++ b/book/website/welcome.md
@@ -3,7 +3,7 @@
 
 _The Turing Way_ is a handbook to reproducible, ethical, inclusive and collaborative data science. 
 
-The project is open source (anyone can [inspect the code](https://github.com/alan-turing-institute/the-turing-way)), open contribution (anyone can {ref}`contribute<ch-contributing>`), and open-licenced (anyone can [re-use the materials](https://github.com/alan-turing-institute/the-turing-way/blob/master/LICENSE.md)).
+The project is open source (anyone can [inspect the code](https://github.com/alan-turing-institute/the-turing-way)), open contribution (anyone can {ref}`contribute<ch-contributing>`), and open licenced (anyone can [re-use the materials](https://github.com/alan-turing-institute/the-turing-way/blob/master/LICENSE.md)).
 
 Our goal is to provide all the information that data scientists in academia, industry, government and the third sector need to ensure that the projects they work on are easy to reproduce and reuse.
 

--- a/book/website/welcome.md
+++ b/book/website/welcome.md
@@ -37,6 +37,7 @@ To join this community, please read our [contribution guidelines](https://github
 More information about the community and the project is available in the {ref}`ch`.
 We look forward to expanding and building _The Turing Way_ together.
 
+
 ```{figure} figures/theturingway-chapters.jpg
 ---
 name: theturingway-chapters
@@ -44,6 +45,7 @@ alt: The Turing Way Guide to reproducible research and it's stucture illustrated
 ---
 _The Turing Way_ project illustration by Scriberia. Original version on Zenodo. http://doi.org/10.5281/zenodo.3695300.
 ```
+
 
 Although _The Turing Way_ receives support and funding from [The Alan Turing Institute](https://www.turing.ac.uk/), the project is designed to be a global collaboration.
 We have contributions from across the UK, and from India, Mexico, Australia, USA, and many European countries.


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

as per #1955, to make it less intimidating (#1851, #1919, probably others) and to direct readers to the recommended ways of interacting with the guide (browse or keyword search).

### List of changes proposed in this PR (pull-request)

- I've tried to cut down the initial message to the bare minimum
  - I've moved out some of the text into a new 'history' section. **This would need expanding or removing before a merge** - it is currently a [stub](https://en.wikipedia.org/wiki/Wikipedia:Stub#Basic_information). I imagine this could be a good place for origin stories, key people, funding thanks etc. This interacts with #1731 - probably makes sense to include a link to a fuller history rather than have a duplicate 'history' on the landing page, unless the plan was for it to be there anyhow.
  - I've cut words where I could.
- I've tried to keep the language impersonal (avoiding language like 'we recommend...' because 'we' seems like an odd concept in this setting). This has meant that the language is quite direct (The option of 'We recommend not trying to read the book from start to end' has been passed over in favor of 'Do not try to read the guide from start to finish'). **Suggestions on how to make this sound friendlier are welcome!**
- I would like to be able to link to a summary page (really just the navigation pane but on a page of its own). I can't find a way to get jupyter book to create this page through URL manipulation, though there might be a way that I haven't found. **Help requested in finding this.**
- Talking or URL manipulation, I assume that there is a better way to link to the search page than with the full hardcoded URL. I hope that someone who understands how this works better than me will be able to **fix this**.
- (Unrelated to the main goal - I've hyphenated 'open source' since it is an adjective in this case.)


### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

Bolded above, but to summarise:
~~- [ ] Extend/remove history section (see note above regards #1731)~~ The history section will arrive at some point, at which point we can work out the best way to link to it.
~~- [ ] Make wording friendlier~~ It's actually fine.
~~- [ ] Find a way to generate a full-page clone of the navigation page, to be linked to from 'browse the chapters'~~ I'm actually happy with people having to use the normal navigation; it's good practice to have them use the standard navigation rather than creating a new/different/redundant navigation path.
~~- [ ] Fix my hacky link to the search page~~ I've actually removed it, see above logic.


### Acknowledging contributors

<!-- Please select the correct box -->

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->

### Updates

- I decided that everything was actually fine! (See crossed out to do list)