### PR TITLE
Remove advice to use C++ testing frameworks for C

### DIFF
--- a/book/website/reproducible-research/testing/testing-guidance.md
+++ b/book/website/reproducible-research/testing/testing-guidance.md
@@ -63,7 +63,6 @@ Find one you like, learn about the features it offers, and make use of them. Com
   - Boost::Test
   - google-test
 - C
-  - all C++ frameworks
   - Check
   - CUnit
 - Python

--- a/book/website/reproducible-research/testing/testing-guidance.md
+++ b/book/website/reproducible-research/testing/testing-guidance.md
@@ -63,8 +63,12 @@ Find one you like, learn about the features it offers, and make use of them. Com
   - Boost::Test
   - google-test
 - C
+  - all C++ frameworks
   - Check
   - CUnit
+```{note}
+While modern C++ and C are still mostly compatible, they're not completely and using test framework interchangeably may not always work.
+```
 - Python
   - pytest (recommended)
   - unittest comes with standard Python library


### PR DESCRIPTION
### Summary

Despite many people thinking that C++ is compatible with C, this is not true in the modern language as C99 diverged, introducing features that were not available in C++ and vice versa. This has continued, with C11 introducing further incompatabilities. This means that you can only universally use a C++ testing framework if you restrict yourself to the C89 standardwhich is obviously now 32 years old!

Because of that, using a C++ testing framework for a C project can run into issues. This is not obvious at first glance, but consider the following which my be present in a header file which would need to be included in a translation unit for a C++ testing framework to make use of a C library:

```
// 'restrict' is not a keyword in C++ so this generates a compiler error:
void myfunction(double* restrict array)

// C++ does not support this because it implements templates which achieves a similar thing:
#define myfunction(X) _Generic((X),
                   int: myfunctioni, \
                   long: myfunctionl, \
                   float: myfunctionf, \
                   double: myfunctiond, \
                   default: myfunction_default)(X)

// C++ doesn't support designated initialisers that can appear in a header:
const int a[] = {[0 ... 9] = 1, [10 ... 99] = 2, [100] = 3 };
```
Some modern C features can be enabled in some C++ compilers by using compiler flags, but this isn't universally true, which makes it hard to recommend. People used to working with GCC often run into issues when switching compilers, because GCC has many language extensions that for e.g. MSVC does not support.

### List of changes proposed in this PR (pull-request)

* Remove "all C++ frameworks" from the list of suggested C testing frameworks


### What should a reviewer concentrate their feedback on?

- [ ] Is removing the advice sensible, or should caveats be added?
- [ ] Everything looks ok?


### Acknowledging contributors

<!-- Please select the correct box -->

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file.
- [x] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file: rpep
