### PR TITLE
Update jupyter book version to 0.11.2

### DIFF
--- a/book/website/_toc.yml
+++ b/book/website/_toc.yml
@@ -547,7 +547,7 @@ chapters:
     - title: Template for Drafting Newsletters
       file: community-handbook/templates/template-newsletter-draft
 
-# ===== Afterword Section ========================================
+# ===== Afterword ========================================
 
 - file: afterword/afterword
   sections:

--- a/book/website/_toc.yml
+++ b/book/website/_toc.yml
@@ -11,12 +11,12 @@
 
 root: welcome
 format: jb-book
-parts:
+chapters:
 
 # ===== Guide for Reproducible Research ========================================
-- caption: Guide for Reproducible Research
+
 - file: reproducible-research/reproducible-research
-  chapters:
+  sections:
   - title: Overview
     file: reproducible-research/overview
     sections:
@@ -234,9 +234,8 @@ parts:
 
 # ===== Guide for Project Design ========================================
 
-- caption: Guide for Project Design
 - file: project-design/project-design
-  chapters:
+  sections:
   - title: Overview of Project Design
     file: project-design/pd-overview
     sections:
@@ -352,9 +351,8 @@ parts:
 
 # ===== Guide for Collaboration ========================================
 
-- caption: Guide for Collaboration
 - file: collaboration/collaboration
-  chapters:
+  sections:
   - title: Getting Started With GitHub
     file: collaboration/github-novice
     sections:
@@ -419,9 +417,8 @@ parts:
 
 # ===== Guide for Ethical Research ========================================
 
-- caption: Guide for Ethical Research
 - file: ethical-research/ethical-research
-  chapters:
+  sections:
   - title: Introduction to Research Ethics
     file: ethical-research/ethics-intro
   - title: Research Ethics Committees Workflows
@@ -453,9 +450,8 @@ parts:
 
 # ===== Community Handbook ========================================
 
-- caption: Community Handbook
 - file: community-handbook/community-handbook
-  chapters:
+  sections:
   - title: Code of Conduct
     file: community-handbook/coc
     sections:
@@ -554,9 +550,8 @@ parts:
 
 # ===== Afterward Section ========================================
 
-- caption: Afterword
 - file: afterword/afterword
-  chapters:
+  sections:
   - title: Legal Disclaimer
     file: afterword/legal-disclaimer
   - title: Glossary

--- a/book/website/_toc.yml
+++ b/book/website/_toc.yml
@@ -15,7 +15,7 @@ parts:
 
 # ===== Reproducible Research Guide ========================================
 - file: reproducible-research/reproducible-research
-  chapters:
+  sections:
   - title: Overview
     file: reproducible-research/overview
     sections:

--- a/book/website/_toc.yml
+++ b/book/website/_toc.yml
@@ -9,11 +9,13 @@
 
 # ===== Main Landing Page ========================================
 
-- file: welcome
+root: welcome
+format: jb-book
+parts:
 
 # ===== Reproducible Research Guide ========================================
 - file: reproducible-research/reproducible-research
-  sections:
+  chapters:
   - title: Overview
     file: reproducible-research/overview
     sections:

--- a/book/website/_toc.yml
+++ b/book/website/_toc.yml
@@ -13,7 +13,8 @@ root: welcome
 format: jb-book
 parts:
 
-# ===== Reproducible Research Guide ========================================
+# ===== Guide for Reproducible Research ========================================
+- caption: Guide for Reproducible Research
 - file: reproducible-research/reproducible-research
   chapters:
   - title: Overview
@@ -231,8 +232,9 @@ parts:
     - title: A Statistical Methods Manuscript
       file: reproducible-research/case-studies/case-study-statistical
 
-# ===== Project Design Guide ========================================
+# ===== Guide for Project Design ========================================
 
+- caption: Guide for Project Design
 - file: project-design/project-design
   chapters:
   - title: Overview of Project Design
@@ -282,8 +284,9 @@ parts:
     - title: Code Styling Tools
       file: project-design/code-styling/code-styling-tools
 
-# ===== Communication Guide ========================================
+# ===== Guide for Communication ========================================
 
+- caption: Guide for Communication
 - file: communication/communication
   chapters:
   - title: Overview of Guide for Communication
@@ -347,8 +350,9 @@ parts:
     - title: Communication Channels
       file: communication/os-comms/os-comms-channels
 
-# ===== Collaboration Guide ========================================
+# ===== Guide for Collaboration ========================================
 
+- caption: Guide for Collaboration
 - file: collaboration/collaboration
   chapters:
   - title: Getting Started With GitHub
@@ -413,7 +417,9 @@ parts:
     - title: Perceived Pros and Cons
       file: collaboration/remote-collab/remote-collab-prosandcons
 
-# ===== Ethical Research Guide ========================================
+# ===== Guide for Ethical Research ========================================
+
+- caption: Guide for Ethical Research
 - file: ethical-research/ethical-research
   chapters:
   - title: Introduction to Research Ethics
@@ -445,8 +451,9 @@ parts:
   - title: Internal Policy Advocacy
     file: ethical-research/internal-policy
 
-# ===== Community Handbook Guide ========================================
+# ===== Community Handbook ========================================
 
+- caption: Community Handbook
 - file: community-handbook/community-handbook
   chapters:
   - title: Code of Conduct
@@ -547,8 +554,8 @@ parts:
 
 # ===== Afterward Section ========================================
 
-- title: Afterword
-  file: afterword/afterword
+- caption: Afterword
+- file: afterword/afterword
   chapters:
   - title: Legal Disclaimer
     file: afterword/legal-disclaimer

--- a/book/website/_toc.yml
+++ b/book/website/_toc.yml
@@ -547,7 +547,7 @@ chapters:
     - title: Template for Drafting Newsletters
       file: community-handbook/templates/template-newsletter-draft
 
-# ===== Afterward Section ========================================
+# ===== Afterword Section ========================================
 
 - file: afterword/afterword
   sections:

--- a/book/website/_toc.yml
+++ b/book/website/_toc.yml
@@ -15,7 +15,7 @@ parts:
 
 # ===== Reproducible Research Guide ========================================
 - file: reproducible-research/reproducible-research
-  sections:
+  chapters:
   - title: Overview
     file: reproducible-research/overview
     sections:
@@ -234,7 +234,7 @@ parts:
 # ===== Project Design Guide ========================================
 
 - file: project-design/project-design
-  sections:
+  chapters:
   - title: Overview of Project Design
     file: project-design/pd-overview
     sections:
@@ -285,7 +285,7 @@ parts:
 # ===== Communication Guide ========================================
 
 - file: communication/communication
-  sections:
+  chapters:
   - title: Overview of Guide for Communication
     file: communication/comms-overview
     sections:
@@ -350,7 +350,7 @@ parts:
 # ===== Collaboration Guide ========================================
 
 - file: collaboration/collaboration
-  sections:
+  chapters:
   - title: Getting Started With GitHub
     file: collaboration/github-novice
     sections:
@@ -415,7 +415,7 @@ parts:
 
 # ===== Ethical Research Guide ========================================
 - file: ethical-research/ethical-research
-  sections:
+  chapters:
   - title: Introduction to Research Ethics
     file: ethical-research/ethics-intro
   - title: Research Ethics Committees Workflows
@@ -448,7 +448,7 @@ parts:
 # ===== Community Handbook Guide ========================================
 
 - file: community-handbook/community-handbook
-  sections:
+  chapters:
   - title: Code of Conduct
     file: community-handbook/coc
     sections:
@@ -549,7 +549,7 @@ parts:
 
 - title: Afterword
   file: afterword/afterword
-  sections:
+  chapters:
   - title: Legal Disclaimer
     file: afterword/legal-disclaimer
   - title: Glossary

--- a/book/website/_toc.yml
+++ b/book/website/_toc.yml
@@ -285,9 +285,8 @@ chapters:
 
 # ===== Guide for Communication ========================================
 
-- caption: Guide for Communication
 - file: communication/communication
-  chapters:
+  sections:
   - title: Overview of Guide for Communication
     file: communication/comms-overview
     sections:

--- a/book/website/requirements.txt
+++ b/book/website/requirements.txt
@@ -6,4 +6,4 @@ matplotlib==3.2.2
 datascience
 folium
 jupyter-book==0.11.2
-sphinxcontrib-bibtex==1.0.0
+sphinxcontrib-bibtex~=2.2.0

--- a/book/website/requirements.txt
+++ b/book/website/requirements.txt
@@ -5,5 +5,5 @@ numpy==1.19.0
 matplotlib==3.2.2
 datascience
 folium
-jupyter-book==0.8.2
+jupyter-book==0.11.2
 sphinxcontrib-bibtex==1.0.0


### PR DESCRIPTION
### Summary

~~Seeing if updating the jupyter book version fixes https://github.com/executablebooks/jupyter-book/issues/1392 / https://github.com/alan-turing-institute/the-turing-way/issues/2034#issuecomment-885987020~~ **Update: it doesn't.**

~~I don't actually know if just changing this line will update the version of jupyter books used (early stage of learning), but I thought I'd try it out on a branch and have a look at the netlify preview to see.~~ **Update: it does.**

# Update / Summary

I have updated the jupyter book version to the latest version and fixed the obvious breaks it caused.
The main thing was that it [required an update to the fields in the toc](https://executablebooks.org/en/latest/updates/2021-06-18-update-toc.html).

I have checked:
- [x] the sidebar links still work
- [x] cross-references still work
- [x] bibliographic references still work  
- [ ] What other things should be checked before merging?

### Who can help?

- Others involved in previous jupyter book upgrades (@martinagvilas, @BatoolMM, @KirstieJane, @yochannah)
- Others with sharp eyes who could scour through and compare the [live site](https://the-turing-way.netlify.app) with the [preview site](https://deploy-preview-2039--the-turing-way.netlify.app/) and try to find any discrepancies.    
