### PR TITLE
Correcting names for links to subchapters

### DIFF
--- a/book/website/project-design/project-repo.md
+++ b/book/website/project-design/project-repo.md
@@ -33,7 +33,7 @@ _The Turing Way_ project illustration by Scriberia. Used under a CC-BY 4.0 licen
 In this chapter, we have described following documents that should be added to a project repository:
 - {ref}`Landing Page - README File<pd-project-repo-readme>`
 - {ref}`Roadmapping<pd-project-repo-roadmapping>`
-- {ref}`Contribution Guidelines<pd-project-repo-contributors>`
+- {ref}`Contributor Pathways<pd-project-repo-contributors>`
 - {ref}`Participation Guidelines<pd-project-repo-participation>`
 
 (pd-project-repo-license)=

--- a/book/website/project-design/project-repo.md
+++ b/book/website/project-design/project-repo.md
@@ -31,10 +31,10 @@ _The Turing Way_ project illustration by Scriberia. Used under a CC-BY 4.0 licen
 ```
 
 In this chapter, we have described following documents that should be added to a project repository:
-- {ref}`landing page or README file<pd-project-repo-readme>`
+- {ref}`Landing Page - README File<pd-project-repo-readme>`
 - {ref}`Roadmapping<pd-project-repo-roadmapping>`
-- {ref}`Contribution Guideline<pd-project-repo-contributors>`
-- {ref}`Contribution Guideline<pd-project-repo-participation>`
+- {ref}`Contribution Guidelines<pd-project-repo-contributors>`
+- {ref}`Participation Guidelines<pd-project-repo-participation>`
 
 (pd-project-repo-license)=
 ## Start by Adding a License


### PR DESCRIPTION
### Summary

Fixing links at the start of the 'Creating repositories' chapter

### List of changes proposed in this PR (pull-request)

- Changed names for links to subchapters

### What should a reviewer concentrate their feedback on?

- [x] Everything looks ok?

### Acknowledging contributors

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
