### PR TITLE
fix makefile

### DIFF
--- a/book/website/reproducible-research/make/make-examples.md
+++ b/book/website/reproducible-research/make/make-examples.md
@@ -398,7 +398,7 @@ more detail. The complete file is:
 
 ALL_CSV = $(wildcard data/*.csv)
 INPUT_CSV = $(wildcard data/input_file_*.csv)
-DATA = $(filter-out $(INPUT_CSV),$(ALL_CSV))
+DATA = $(filter $(INPUT_CSV),$(ALL_CSV))
 FIGURES = $(patsubst data/%.csv,output/figure_%.png,$(DATA))
 
 .PHONY: all clean
@@ -432,12 +432,12 @@ Next, we create a variable to list only the data files that we're interested
 in by filtering out the ``INPUT_CSV`` from ``ALL_CSV``:
 
 ```makefile
-DATA = $(filter-out $(INPUT_CSV),$(ALL_CSV))
+DATA = $(filter $(INPUT_CSV),$(ALL_CSV))
 ```
 
 This line uses the
-[``filter-out``](https://www.gnu.org/software/make/manual/make.html#index-filter_002dout)
-function to remove items in the ``INPUT_CSV`` variable from the ``ALL_CSV``
+[``filter``](https://www.gnu.org/software/make/manual/make.html#index-filter)
+function to remove items that don't match the ``INPUT_CSV`` variable from the ``ALL_CSV``
 variable.  Note that we use both the ``$( ... )`` syntax for functions and
 variables. Finally, we'll use the ``DATA`` variable to create a ``FIGURES``
 variable with the desired output:

--- a/book/website/reproducible-research/make/make-examples.md
+++ b/book/website/reproducible-research/make/make-examples.md
@@ -399,13 +399,13 @@ more detail. The complete file is:
 ALL_CSV = $(wildcard data/*.csv)
 INPUT_CSV = $(wildcard data/input_file_*.csv)
 DATA = $(filter $(INPUT_CSV),$(ALL_CSV))
-FIGURES = $(patsubst data/%.csv,output/figure_%.png,$(DATA))
+FIGURES = $(patsubst data/input_file_%.csv,output/figure_%.png,$(DATA))
 
 .PHONY: all clean
 
 all: output/report.pdf
 
-$(FIGURES): output/figure_%.png: data/%.csv scripts/generate_histogram.py
+$(FIGURES): output/figure_%.png: data/input_file_%.csv scripts/generate_histogram.py
 	python scripts/generate_histogram.py -i $< -o $@
 
 output/report.pdf: report/report.tex $(FIGURES)


### PR DESCRIPTION
The example makefile was filtering out all input csv files which results in an empty `DATA` variable.

Instead I think the intent is to keep only input csv files (though it is a bit redundant, since one could just use `INPUT_CSV` directly, but I assume this is for educational purposes)

Also fixes pattern substitutions, since these where generating `figure_input_file_{N}` instead of `figure_{N}`.

Would be good to actually run the files as tests in CI