### PR TITLE
fix EU2016protection link

### DIFF
--- a/book/website/reproducible-research/open/open-data.md
+++ b/book/website/reproducible-research/open/open-data.md
@@ -61,7 +61,7 @@ It may also be possible to provide the data in such a format that researchers ca
 For example, a user may be able to send a query to retrieve the mean of a dataset, but not be able to access any of the individual data points.
 
 Many fields of scientific disciplines involve working with sensitive personal data.
-Their management is well regulated in data protection legislation (in Europe through national implementations of the General Data Protection Regulation) and ethics procedures as they are established in most research institutions {cite:t} `EU2016protection`.
+Their management is well regulated in data protection legislation (in Europe through national implementations of the General Data Protection Regulation) and ethics procedures as they are established in most research institutions {cite:t}`EU2016protection`.
 
 (rr-open-data-barriers-consent)=
 ### Consent

--- a/book/website/reproducible-research/open/open-data.md
+++ b/book/website/reproducible-research/open/open-data.md
@@ -61,7 +61,7 @@ It may also be possible to provide the data in such a format that researchers ca
 For example, a user may be able to send a query to retrieve the mean of a dataset, but not be able to access any of the individual data points.
 
 Many fields of scientific disciplines involve working with sensitive personal data.
-Their management is well regulated in data protection legislation (in Europe through national implementations of the General Data Protection Regulation) and ethics procedures as they are established in most research institutions {cite:t}`EU2016protection`.
+Their management is well regulated in data protection legislation (in Europe through national implementations of the General Data Protection Regulation) and ethics procedures as they are established in most research institutions. {cite:t}`EU2016protection`.
 
 (rr-open-data-barriers-consent)=
 ### Consent


### PR DESCRIPTION
Addressing this issue (https://github.com/alan-turing-institute/the-turing-way/issues/2085)

### Summary

This should fix issue [#2085](https://github.com/alan-turing-institute/the-turing-way/issues/2085). I believe this extra space between the cite brackets and citation name is causing the issue on the Open Data page.

Fixes #2085

### List of changes proposed in this PR (pull-request)

- Remove Space

### What should a reviewer concentrate their feedback on?

- I am unable to run this on my local machine atm to confirm the fix, but wanted to suggest this chance asap to address the issue

### Acknowledging contributors

<!-- Please select the correct box -->

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file.
- [x] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file: <!-- dingaaling -->
