### PR TITLE
Update .zenodo.json - upload type "Book" -> "Publication"

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -5,7 +5,7 @@
   "title": "The Turing Way",
   "description": "The Turing Way is an open source community-driven guide to reproducible, ethical, inclusive and collaborative data science. The Turing Way book is collaboratively developed by its diverse community of researchers, learners, educators, and other stakeholders and shared under an open license.",
   "license": "CC-BY 4.0 & MIT",
-  "upload_type": "Book",
+  "upload_type": "Publication",
   "keywords": [
     "reproducibility",
     "data-science",

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -5,7 +5,7 @@
   "title": "The Turing Way",
   "description": "The Turing Way is an open source community-driven guide to reproducible, ethical, inclusive and collaborative data science. The Turing Way book is collaboratively developed by its diverse community of researchers, learners, educators, and other stakeholders and shared under an open license.",
   "license": "CC-BY 4.0 & MIT",
-  "upload_type": "Publication",
+  "upload_type": "publication",
   "keywords": [
     "reproducibility",
     "data-science",


### PR DESCRIPTION
To comply with their controlled vocabulary, I am changing Book to Publication: https://developers.zenodo.org/#representation (No other option seem to work)