### PR TITLE
Fix typo on CoC acknowledgements title

### DIFF
--- a/book/website/_toc.yml
+++ b/book/website/_toc.yml
@@ -533,7 +533,7 @@ parts:
         file: community-handbook/coc/coc-reporting
       - title: Enforcement Manual
         file: community-handbook/coc/coc-enforcement
-      - title: Acnowledgements
+      - title: Acknowledgements
         file: community-handbook/coc/coc-acknowledgement
     - title: Style Guide
       file: community-handbook/style


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

Fixes a typo I noticed in the spelling of "acknowledgements" in the TOC for Community Handbook > CoC  > Acknowledgements 

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* replaces "acnowledgements" with "acknowledgements"

### What should a reviewer concentrate their feedback on?

- [ ] Has Cass spelled "acknowledgements" correctly in the _toc.yml? 
- [ ] Is there anywhere other than the _toc.yml where this needs to be changed?



### Acknowledging contributors

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
