### PR TITLE
Remove given-names field in CITATION.cff file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,6 @@ cff-version: 1.2.0
 message: "To reference the latest version of The Turing Way, please cite it as below."
 authors:
 - family-names: "The Turing Way Community"
-  given-names: "."
 title: "The Turing Way: A handbook for reproducible, ethical and collaborative research"
 version: 1.0.1
 identifiers:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "To reference the latest version of The Turing Way, please cite it as below."
 authors:
-- family-names: "The Turing Way Community"
+- name: "The Turing Way Community"
 title: "The Turing Way: A handbook for reproducible, ethical and collaborative research"
 version: 1.0.1
 identifiers:


### PR DESCRIPTION
Having this field in the file causes weird changes when we run `cffconvert` to generate a `.zenodo.json` file. See: https://github.com/alan-turing-institute/the-turing-way/pull/2411#discussion_r882534240 The citation file is still valid according to `cffconvert --validate`