### PR TITLE
Fix tiny mini typo in main README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Connect with others and discuss your ideas on Slack using [this invitation link]
 We also have a Gitter chat room (if you prefer an open source alternative for chat) and we'd love for you to swing by to say hello at <https://gitter.im/alan-turing-institute/the-turing-way>.
 The room is also accessible with a [Matrix](https://matrix.org) account at [#alan-turing-institute_the-turing-way:gitter.im](https://matrix.to/#/#alan-turing-institute_the-turing-way:gitter.im).
 
-#### Recieve Updates
+#### Receive Updates
 
 We have a *tinyletter* mailing list to which we send monthly project updates.
 Subscribe at <https://tinyletter.com/TuringWay>.


### PR DESCRIPTION
### Summary

<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent. For example: "Fixes #58", or "Addresses (but does not close) #238". -->

Just a tiny mini typo that bothered me.


### Acknowledging contributors

<!-- Please select the correct box -->

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
