### PR TITLE
Automate closing talk issues in a workflow

### DIFF
--- a/.github/workflows/close-talk-issues.yml
+++ b/.github/workflows/close-talk-issues.yml
@@ -7,6 +7,8 @@ on:
     # Run every Monday at 00:00 UTC
     - cron: "0 0 * * 1"
 
+# We set environment variables here so that they are easy to change if the labels
+# or the Community Manager changes
 env:
   # The label assigned to talks issues
   TALK_LABEL: "talks-and-workshops"

--- a/.github/workflows/close-talk-issues.yml
+++ b/.github/workflows/close-talk-issues.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Close talk issues that have happened and create a new issue to promote them in the newsletter
         shell: python
         run: |
+          import re
+          from datetime import datetime
+
           from ghapi import GhApi, paged
 
           # Set variables
@@ -62,14 +65,23 @@ jobs:
           # Blank list to store issues to be closed in
           issues_to_close = []
 
+          # Get today's date
+          today = datetime.now()
+
+          # Establish regular expression for matching dates
+          pattern = re.compile("[0-9]{4}-[0-1][0-9]-[0-3][0-9]")
+
           # Loop over talk issues and determine if they have happened or not yet
           for paged_issues in all_issues:
               for issue in paged_issues:
-                  #=== Add in code to extract date from issue body here ===#
-                  # body = issue.body
+                  # Extract date from issue body
+                  match = pattern.match(issue.body)
 
-                  #=== Add code to establish if date is in the past or not here ===#
-                  # to_be_closed = some_bool_expr
+                  # Convert into a datetime object
+                  talk_date = datetime.strptime(match[0], "%Y-%m-%d")
+
+                  # Establish if talk_date is more than 7 days in the past from today
+                  to_be_closed = (talk_date - today).days < -7
 
                   if to_be_closed:
                       issue_info = {

--- a/.github/workflows/close-talk-issues.yml
+++ b/.github/workflows/close-talk-issues.yml
@@ -1,0 +1,132 @@
+name: Close talk issues that have happened
+
+on:
+  # Manually run the workflow from the Actions page
+  workflow_dispatch:
+  schedule:
+    # Run every Monday at 00:00 UTC
+    - cron: "0 0 * * 1"
+
+env:
+  # The label assigned to talks issues
+  TALK_LABEL: "talks-and-workshops"
+  # The label to assign to the new issue reagrding the newsletter
+  NEWSLETTER_LABEL: "newsletter"
+  # The GitHub handle of the person responsible for collating this info into the
+  # newsletter. They will be assigned to the new issue this workflow will create.
+  COMMUNITY_MANAGER: "aleesteele"
+
+jobs:
+  close-talk-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      # Ensure GITHUB_TOKEN has permissions to create, update, and comment on issues
+      issues: write
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install ghapi to interact with the GitHub REST API
+        run: |
+          pip install ghapi
+
+      - name: Close talk issues that have happened and create a new issue to promote them in the newsletter
+        shell: python
+        run: |
+          from ghapi import GhApi, paged
+
+          # Set variables
+          owner, repo = r"""${{ github.repository }}""".split("/")
+          talk_label = r"""${{ env.TALK_LABEL }}"""
+          newsletter_label = r"""${{ env.NEWSLETTER_LABEL }}"""
+          community_manager = r"""${{ env.COMMUNITY_MANAGER }}"""
+          github_token = r"""${{ secrets.GITHUB_TOKEN }}"""
+
+          # Authenticate against the GitHub REST API
+          api = GhApi(token=github_token)
+
+          # Get all the open issues in the repo that have talk_label
+          all_issues = paged(
+              api.issues.list_for_repo,
+              owner=owner,
+              repo=repo,
+              state="open",
+              labels=talk_label,
+              per_page=100,
+          )
+
+          # Blank list to store issues to be closed in
+          issues_to_close = []
+
+          # Loop over talk issues and determine if they have happened or not yet
+          for paged_issues in all_issues:
+              for issue in paged_issues:
+                  #=== Add in code to extract date from issue body here ===#
+                  # body = issue.body
+
+                  #=== Add code to establish if date is in the past or not here ===#
+                  # to_be_closed = some_bool_expr
+
+                  if to_be_closed:
+                      issue_info = {
+                          "repository_url": issue.repository_url,
+                          "issue_number": issue.number,
+                      }
+                      issues_to_close.append(issue_info)
+
+          # Close talk issues that are in the past
+          for issue in issues_to_close:
+              api.issues.update(
+                  owner=owner,
+                  repo=repo,
+                  issue_number=issue["issue_number"],
+                  state="closed",
+              )
+
+          # Construct Markdown text listing all the issues that have been closed
+          body = (
+              "Please add the following talks to the next newsletter!\n\n"
+              + "\n".join([f"- {issue['repository_url']}" for issue in issues_to_close])
+          )
+
+          # Check if a newsletter issue is already open
+          all_issues = paged(
+              api.issues.list_for_repo,
+              owner=owner,
+              repo=repo,
+              state="open",
+              creator="github-actions[bot]",
+              labels=newsletter_label,
+              per_page=100,
+          )
+
+          for paged_issues in all_issues:
+              if paged_issues:
+                  create_new_issue = False
+                  # We take the number of the first returned issue here
+                  issue_number = paged_issues[0].number
+              else:
+                  create_new_issue = True
+                  issue_number = None
+              break
+
+          if create_new_issue:
+              # An issue doesn't exist, create one
+              api.issues.create(
+                  owner=owner,
+                  repo=repo,
+                  title="Recent talks to promote in the newsletter",
+                  body=body,
+                  labels=newsletter_label,
+                  assignee=community_manager,
+              )
+          else:
+              # An issue exists, add list of newly closed issues as a comment
+              api.issues.create_comment(
+                  owner=owner,
+                  repo=repo,
+                  issue_number=issue_number,
+                  body=body,
+              )


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent. For example: "Fixes #58", or "Addresses (but does not close) #238". -->

- Finds all issues with 'talks-and-workshops' labels
- Closes any of these issues whose talk date is in the past
- Either, creates a new issue to promote the closed talk issues in the
  newsletter and assigns the community manager to it,  or...
- Adds a comment to an existing newsletter issue with newly closed talk issues

The idea behind creating a new issue that lists closed talk issues is to reduce the number of pings the Community Manager receives. Similarly motivated is commenting on an already existing issue, rather than opening a new one.

#### TODOs

- [x] Add logic to extract the date from issues that are opened using the template proposed in https://github.com/alan-turing-institute/the-turing-way/pull/2570
- [x] Add logic to establish whether or not that date is in the past

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* close-talk-issues.yml

### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [ ] *Lorem ipsum dolor sit amet, consectetur adipiscing.*
- [ ] Everything looks ok?


### Acknowledging contributors

<!-- Please select the correct box -->

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
