### PR TITLE
[WIP] update in solidarity to allow for hyperlinks to repos that use "/master"

### DIFF
--- a/.github/in-solidarity.yml
+++ b/.github/in-solidarity.yml
@@ -1,6 +1,10 @@
 rules:
   master:
-    level: failure
+    level: off
+  master_excluding_when_with_preceding_slash:
+  regex:
+    - /(?<!\/)master/g
+  level: failure
   slave:
     level: failure
   whitelist:

--- a/.github/in-solidarity.yml
+++ b/.github/in-solidarity.yml
@@ -1,10 +1,6 @@
 rules:
   master:
-    level: off
-  master_excluding_when_with_preceding_slash:
-  regex:
-    - /(?<!\/)master/g
-  level: failure
+    level: warning
   slave:
     level: failure
   whitelist:


### PR DESCRIPTION
Tweaking the 'in solidarity' settings to create a special case that allows the word "master" to be used, only in the situation whereby it is immediately preceded by a "/", as seen in https://github.com/alan-turing-institute/the-turing-way/pull/2339 and described in #2343.

Currently seeking two specific types of input:
- Is this a good idea?
- How do we test that this works? (I can't see how to test this without approving it and then purposefully doing other PRs which should pass/fail and seeing whether it works as intended, but I'd prefer to test it without having to approve this PR)