### PR TITLE
added link to slack to 'ttw slack' issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/give_a_talk.yml
+++ b/.github/ISSUE_TEMPLATE/give_a_talk.yml
@@ -26,7 +26,7 @@ body:
       label: Checklist
       description: Access TTW slides, check acknowledgements, and share your presentation
       options:
-        - label: Schedule your talk and let the community know in TTW Slack. If you’d like feedback and/or to schedule a practice talk, ask in the TTW Slack!
+        - label: Schedule your talk and let the community know in [TTW Slack](https://theturingway.slack.com/). If you’d like feedback and/or to schedule a practice talk, ask in the TTW Slack!
         - label: Download template(s) from the [promotion pack](https://drive.google.com/drive/folders/1mzGmbJkPnP5q1goQesxDc_E5zAPL0eTF?usp=sharing) to ensure stylistic consistency
         - label: Generate a DOI on [Zenodo](zenodo.org/) and upload your slides when ready, preferably in the original format along with a PDF or any other format you are using. Tag with "the-turing-way" under **Communities**. Zenodo allows [versioning](https://help.zenodo.org/#versioning), so we encourage you to upload your slides before your talk and add additional file(s) with any changes after
         - label: Check all ackowledgements (bottom right corner of each slide) and add the DOI for your presentation and your personal contact info if desired


### PR DESCRIPTION
### Summary
- added link to TTW slack in the issue template for 'give ttw talk'