### PR TITLE
add `journal` field to supress jupyter-book warning

### DIFF
--- a/book/website/_bibliography/references.bib
+++ b/book/website/_bibliography/references.bib
@@ -1110,7 +1110,7 @@
   month = dec,
   eprint = {1912.04977},
   eprinttype = {arxiv},
-  journal = {arXiv},
+  journal = {arXiv:1912.04977 [cs]},
   archiveprefix = {arXiv},
 }
 

--- a/book/website/_bibliography/references.bib
+++ b/book/website/_bibliography/references.bib
@@ -1110,6 +1110,7 @@
   month = dec,
   eprint = {1912.04977},
   eprinttype = {arxiv},
+  journal = {arXiv},
   archiveprefix = {arXiv},
 }
 


### PR DESCRIPTION
Part of #2611 

```
←[91mC:\Users\cege-user\Documents\the-turing-way\book\website\afterword\bibliography.md:6: WARNING: missing journal in kairouzAdvancesOpenProblems2019←[39;49;00m
```