### PR TITLE
Bumping the version of python used in CI to 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python_version: [3.7, 3.8]
+        python_version: [3.10]
       fail-fast: false  # Don't cancel all jobs if one fails
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
3.7 is no longer supported by newer versions of numpy.

https://github.com/alan-turing-institute/the-turing-way/pull/2592#issuecomment-1229036518