### PR TITLE
fix broken alt text formatting (must be on one line)

### DIFF
--- a/book/website/reproducible-research/open/open-access.md
+++ b/book/website/reproducible-research/open/open-access.md
@@ -107,8 +107,7 @@ For instance, the accepted version could be made publicly available after public
 ---
 height: 500px
 name: routes-to-OA
-alt: An image of a train showing the routes to open access publishing. The green route is signalled as free and shows a preprint server at the start of the journey and self archive at the end. 
-The **gold and diamond** routes are signalled as author pay and funder or institution pay and show the publish in an open access journal part of the journey.
+alt: An image of a train showing the routes to open access publishing. The green route is signalled as free and shows a preprint server at the start of the journey and self archive at the end. The gold and diamond routes are signalled as author pay and funder or institution pay and show the publish in an open access journal part of the journey.
 ---
 Routes to publishing openly.
 _The Turing Way_ project illustration by Scriberia. Used under a CC-BY 4.0 licence. Original version on Zenodo. [http://doi.org/10.5281/zenodo.5706310](http://doi.org/10.5281/zenodo.5706310)


### PR DESCRIPTION
Formatting fix as part of #2611.
Was meaning that an image didn't display.

```
←[31mC:\Users\cege-user\Documents\the-turing-way\book\website\reproducible-research\open\open-access.md:106: ERROR: Directive 'figure': Invalid options YAML: while scanning a simple key
  in "<unicode string>", line 4, column 1:
    The **gold and diamond** routes  ...
    ^
could not find expected ':'
  in "<unicode string>", line 5, column 1:

    ^

---
height: 500px
name: routes-to-OA
alt: An image of a train showing the routes to open access publishing. The green route is signalled as free and shows a preprint server at the start of the journey and self archive at the end.
The **gold and diamond** routes are signalled as author pay and funder or institution pay and show the publish in an open access journal part of the journey.
---
Routes to publishing openly.
_The Turing Way_ project illustration by Scriberia. Used under a CC-BY 4.0 licence. Original version on Zenodo. [http://doi.org/10.5281/zenodo.5706310](http://doi.org/10.5281/zenodo.5706310)←[39;49;00m

```