### PR TITLE
Restore contributing chapter

### DIFF
--- a/book/website/community-handbook/contributing.md
+++ b/book/website/community-handbook/contributing.md
@@ -1,0 +1,20 @@
+(ch-contributing)=
+# Contributing and Developing Chapters - Templates and Workflow
+
+As _The Turing Way_ project grows and evolves, we actively welcome and encourage continuous contributions from community members in the form of new chapters and case studies.
+However, these new contributions need to be consistent with the overall theme, purpose, format, and style of the book's existing content.
+
+Since _The Turing Way_ is written asynchronously by multiple authors around the world, we created a series of templates to guide different kinds of content development while maintaining a consistent format of the book.
+
+```{figure} ../figures/that-could-be-a-chapter.jpg
+---
+height: 400px
+name: that-could-be-a-chapter
+alt: A sketch of Kirstie saying “That could be a chapter”
+---
+"That could be a chapter in The Turing Way!" - Kirstie Whitaker. _The Turing Way_ project illustration by Scriberia. Used under a CC-BY 4.0 licence. DOI: [10.5281/zenodo.3332807](https://doi.org/10.5281/zenodo.3332807).
+```
+
+This chapter provides a brief overview of the workflow for writing chapters and case studies for _The Turing Way_.
+We encourage you to read through and follow the recommendations if you wish to make a contribution.
+Also, ensure that you read our [Contributor Guidelines](https://github.com/alan-turing-institute/the-turing-way/blob/main/CONTRIBUTING.md) in addition to our [style](https://the-turing-way.netlify.app/community-handbook/style.html) and [consistency](https://the-turing-way.netlify.app/community-handbook/consistency.html) recommendations as you prepare your contributions.


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent. For example: "Fixes #58", or "Addresses (but does not close) #238". -->

Contributes to #2674
Contributes to #2611 

Restore the "Contributing and Developing Chapters - Templates and Workflow" top level page, fixing toctree warnings.

This page was removed in 0af3a92a. I think this may have been a mistake as the other pages in the chapter, and the figure, remained in the repository.

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* Restore the chapter's introductory page

### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [ ] Everything looks ok?
- [ ] Should this have been removed?

### Acknowledging contributors

<!-- Please select the correct box -->

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
