### PR TITLE
Added GitHub workshops to README

### DIFF
--- a/workshops/README.md
+++ b/workshops/README.md
@@ -1,6 +1,6 @@
 # Workshops
 
-This directory contains materials for the [Boost your research reproducibility with Binder](boost-research-reproducibility-binder) and [Build a BinderHub](build-a-binderhub) workshops in Manchester and London (Boost your research reproducibility) and Sheffield (Build a BinderHub) in March 2019.
+This directory contains materials for the [Boost your research reproducibility with Binder](boost-research-reproducibility-binder) and [Build a BinderHub](build-a-binderhub) workshops in Manchester and London (Boost your research reproducibility) and Sheffield (Build a BinderHub) in March 2019, and [Introduction to GitHub](github-workshop) workshops.
 
 In each folder you'll find:
 


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

This Pull Request fixes #2697 by adding in a description about the contents of the folder so that it reflects that the folder also has content about github workshops. 

### List of changes proposed in this PR (pull-request)



* Made edit to description
* *Lorem ipsum dolor sit amet, consectetur adipiscing.*


### What should a reviewer concentrate their feedback on?

- [x] Everything looks ok?


### Acknowledging contributors

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file.

