### PR TITLE
Set skipCI to true

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -5,7 +5,7 @@
   "imageSize": 100,
   "contributorsPerLine": 7,
   "badgeTemplate": "[![All Contributors](https://img.shields.io/badge/all_contributors-<%= contributors.length %>-orange.svg)](#contributors)",
-  "skipCi": false,
+  "skipCi": true,
   "contributorsSortAlphabetically": true,
   "contributors": [
     {


### PR DESCRIPTION
### Summary

In order to better facilitate adding lots of new contributors during Hacktober, and more generally, I propose turning off CI for allcontrib PRs. This shouldn't open us to any risk (they still need to be reviewed), but it means that they can be quickly reviewed, and so it's less likely to get backed up.

This undoes #1021, which shouldn't be an issue anymore since we no longer use Travis.

