### PR TITLE
Add a note about YAML to the formatting consistency checklist

### DIFF
--- a/book/website/community-handbook/consistency.md
+++ b/book/website/community-handbook/consistency.md
@@ -44,12 +44,13 @@ Pathway to maintaining consistency. _The Turing Way_ project illustration by Scr
 
 #### Formatting
 
-REQUIREMENT | CHECK
------------ | -----
+REQUIREMENT | CHECK | EXAMPLE
+----------- | ----- | -------
 Hard | Use Markdown for creating your content (see this [WordPress cheatsheet](https://wordpress.com/support/markdown-quick-reference/)).
 Hard | Use the headers in sequential order. For example, starting the top level with h1 tag `#`, second-level header with h2 tag `##` and so on. |
 Hard | Add labels to chapters, subchapters and images to enable cross-referencing as described in the {ref}`style guide<ch-style-crossref>` |
 Hard | Use `MyST` for image formatting as described in the {ref}`style guide<ch-style-figures>` | Use public domain images that are less than 1MB in size and cite appropriately.
+Hard | If you are using a colon (`:`) in the title of your chapter/subchapter, ensure that the whole title is escaped with quotation marks (`"`) in the `_toc.yml` file. Not doing so will cause the book build to fail due to YAML errors. | `- title: "Case Studies: Choosing an ML License"`
 Soft | Ensure that the names of chapters/subchapters are short and map exactly to how they are titled in the `_toc.yml` |
 Soft | Ensure proper title-casing for headers | Capitalise the first, last and 'important' words of every title; for example, 'Snow White and the Seven Dwarves'.
 


### PR DESCRIPTION
Attempting to avoid cases of https://github.com/alan-turing-institute/the-turing-way/pull/2726#discussion_r995649876 where a desire to put a colon in a title, without escaping it, can break the book