### PR TITLE
Auto-format YAML with prettier and pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+# pre-commit is a tool to perform a predefined set of tasks manually and/or
+# automatically before git commits are made. pre-commit can also be run in CI
+# on Pull Requests and will auto-commit corrections to the PR for consistency.
+#
+# Config reference: https://pre-commit.com/#pre-commit-configyaml---top-level
+#
+# How to install locally
+#
+# - pip install pre-commit
+#
+# Common tasks
+#
+# - Run on all files:   pre-commit run --all-files
+# - Register git hooks: pre-commit install --install-hooks
+#
+repos:
+  # Autoformat: yaml
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.0.0-alpha.1
+    hooks:
+      - id: prettier

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,13 @@
+# To create a minimal change suggestion, prettier was introduced to auto-format
+# the YAML files only. It is absolutely reasonable to auto-format markdown files
+# and json files as well, but for now, let's make prettier only auto-format
+# YAML.
+# NOTE: .cff files are a type of YAML
+#
+**/*.md
+**/*.json
+
+# Other file types we should always ignore as they are likely auto-generated
+#
+**/*.css
+**/*.js


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent. For example: "Fixes #58", or "Addresses (but does not close) #238". -->

In https://github.com/alan-turing-institute/the-turing-way/pull/2726, there was an issue with the book build due to incorrectly formatted YAML. @aleesteele and I suggested it would be a good idea to enforce YAML formatting since it is a tricky thing to hand-edit and book build failures are not super informative.

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* Configured [pre-commit](https://pre-commit.com/)
  * This is a tool that can be used locally to perform certain, specified actions just before git creates a commit
  * It can also be used in CI so that, for any open Pull Requests, if the files would have been edited when running pre-commit locally, an extra commit applying these changes would be added to the PR
* Configured [prettier](https://prettier.io/), which will be executed by pre-commit and perform the auto-formatting
  * Provided a `.prettierignore` file to restrict which files will be auto-formatted to only YAML. We can change this file as needed to include other file we would like to be auto-formatted.

This combination of pre-commit and prettier is a very common workflow among open source projects.

### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

There will be three commits on this repo:

* The two original commits I made containing the pre-commit and prettier configuration files described above
  * [prettier config commit](https://github.com/alan-turing-institute/the-turing-way/commit/a2056934c4263ea5eed693c115d0ff691eab4900)
  * [pre-commit config commit](https://github.com/alan-turing-institute/the-turing-way/commit/39e3e9dc5b5ca3570aeaa7d31649d142f68c4ba4)
* An automatically generated commit applying prettier auto-formatting to YAML files, by pre-commit
  * [link TBA]

- [ ] Does everything look ok?

### Acknowledging contributors

<!-- Please select the correct box -->

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
