### PR TITLE
remove remaining checklists and update style guide

### DIFF
--- a/book/website/community-handbook/consistency/consistency-formatting.md
+++ b/book/website/community-handbook/consistency/consistency-formatting.md
@@ -79,27 +79,7 @@ This is also described in the {ref}`Style Guide<ch-style-custom-styling-videos>`
 #### Writing Checklists
 
 When writing a new chapter for _The Turing Way_, you might include a Checklist subchapter that itemises key action points you want readers to take based on the chapter content.
-For earlier chapters in _The Turing Way_, this subchapter is written in Markdown as a Task List with checkboxes:
-
-```
-# Checklist
-- [ ] Item One
-- [ ] Item Two
-- [ ] Item Three
-
-```
-
-However, the checkboxes do not display as intended in the online version of the book, for example:
-
-```{figure} ../../figures/checklist-formatting.png
----
-name: checklist-formatting
-alt: When the Checklist subchapter of any chapter is written in Markdown as a Task List with checkboxes, square brackets are displayed rather than checkboxes in the web version of the book.
----
-Checkboxes are displayed as square brackets in the web version of the book.
-```
-
-Thus, we recommend that you format your Checklist subchapters as unordered lists in your future contributions, and edit earlier chapters that follow the other convention:
+We recommend that you format your Checklist subchapters as unordered lists:
 
 ```
 # Checklist
@@ -108,11 +88,6 @@ Thus, we recommend that you format your Checklist subchapters as unordered lists
 - Item Three
 
 ```
-#### Demo
-
-<div class="video-container">
-    <iframe width="560" height="315" src="https://www.youtube.com/embed/oe2Up1pU5DY" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-</div>
 
 (ch-consistency-formatting-hr-headers)=
 ### Check 2: Use headers in sequential order.

--- a/book/website/reproducible-research/code-quality/code-quality-resources.md
+++ b/book/website/reproducible-research/code-quality/code-quality-resources.md
@@ -4,15 +4,15 @@
 
 ### For code auto-formatting
 
-- [ ] Write your development code in your favourite IDE/text-editor.
-- [ ] Enable auto formatting in your editor by tweaking the preferences/settings.
-- [ ] Type `Ctrl + s` (windows, linux) or `⌘ + s` (mac) to save the work to format the code.
+- Write your development code in your favourite IDE/text-editor.
+- Enable auto formatting in your editor by tweaking the preferences/settings.
+- Type `Ctrl + s` (windows, linux) or `⌘ + s` (mac) to save the work to format the code.
 
 ### For static code analysis
 
-- [ ] Build the project to enable `linters` to spot the errors/warnings in the code (if any).
-- [ ] Make relevant changes and repeat the above step.
-- [ ] {ref}`Commit and push<rr-vcs-git-commit>` the changes to remote **Github/GitLab/BitBucket** repository to run the pre-deployment tests.
+- Build the project to enable `linters` to spot the errors/warnings in the code (if any).
+- Make relevant changes and repeat the above step.
+- {ref}`Commit and push<rr-vcs-git-commit>` the changes to remote **Github/GitLab/BitBucket** repository to run the pre-deployment tests.
 
 ## Further reading
 

--- a/book/website/reproducible-research/testing/testing-checklist.md
+++ b/book/website/reproducible-research/testing/testing-checklist.md
@@ -18,10 +18,10 @@ Do not be discouraged if this list of tasks seems insurmountable.
 <a name="Good_practice_checks"></a>
 ## Good practice checks
 
-- [ ] Document the tests and how to run them.
-  - [ ] Write scripts to set up and configure any resources that are needed to run the tests.
-- [ ] Pick and make use of a testing framework.
-- [ ] Run the tests regularly.
-  - [ ] Automate the process of running tests. Consider making use of continuous integration (see continuous integration chapter) to do this.
-- [ ] Check the code coverage of your tests and try to improve it.
-- [ ] Engage in code review with a partner.
+- Document the tests and how to run them.
+  - Write scripts to set up and configure any resources that are needed to run the tests.
+- Pick and make use of a testing framework.
+- Run the tests regularly.
+  - Automate the process of running tests. Consider making use of continuous integration (see continuous integration chapter) to do this.
+- Check the code coverage of your tests and try to improve it.
+- Engage in code review with a partner.


### PR DESCRIPTION
Closes #1497

I left `community-handbook\bookdash\bookdash-logistics.md` alone because it is plausible that a user might copy the raw version of that document into a program where checkboxes actually do work