### PR TITLE
fix formatting of tip block

### DIFF
--- a/book/website/reproducible-research/rdm/rdm-spreadsheets.md
+++ b/book/website/reproducible-research/rdm/rdm-spreadsheets.md
@@ -36,11 +36,11 @@ This includes:
 As a test for your spreadsheet compatibility with reproducible research, export your data from the spreadsheet to the CSV format and reopen it.
 If you can still get all the information that you stored in your sheet, then your data is fine.
 
-```
-Tip: If you want to use color to help with a rapid highlight in your document, create a new column to indicate which cells are highlighted (it becomes a part of your data).
+```{tip}
+If you want to use color to help with a rapid highlight in your document, create a new column to indicate which cells are highlighted (it becomes a part of your data).
 In addition to the visual feedback, you can now also use this information to filter or sort your data and get the highlighted cells quickly.
-
 ```
+
 (rr-rdm-spreadsheets-format)=
 ## 2. Tidy Format For Spreadsheets
 


### PR DESCRIPTION
### Summary 
This tip was formatted as code, which seems to be a typo:

![Screenshot 2022-11-15 at 2 43 37 PM](https://user-images.githubusercontent.com/192372/202031716-578446a0-356d-4ae2-92f6-a486d51755f3.png)


### List of changes proposed in this PR (pull-request)
This commit adds the `{tip}` admonition tag.
