### PR TITLE
modify one of the orcid figure names to avoid a reference clash

### DIFF
--- a/book/website/communication/citable/citable-orcid.md
+++ b/book/website/communication/citable/citable-orcid.md
@@ -28,7 +28,7 @@ You can also use your ORCID profile to create a CV using [ROpenSci package rorci
 
 ```{figure} ../../figures/orcid-ids.*
 ---
-name: orcid-ids
+name: orcid-ids2
 alt: A researcher surrounded by a ring formed of all her different outputs, linked by an ORCID. Text reads "ORCID IDs" and "One Ring to Rule All Outputs."
 ---
 ORCID IDs link all your research outputs together.


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

Currently, building the book prompts this pair of errors:

- WARNING: duplicate label orcid-ids, other instance in C:\Users\cege-user\Documents\the-turing-way_main\book\website\communication\citable\citable-orcid.md←[39;49;00m
- WARNING: duplicate label orcid-ids, other instance in C:\Users\cege-user\Documents\the-turing-way_main\book\website\communication\citable.md←[39;49;00m

To resolve this, I have renamed one of the figure reference names. 

Not listed in the original errors of #2611, since it has been introduced since, but it seems worth linking it back to that. 

### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [ ] *Lorem ipsum dolor sit amet, consectetur adipiscing.*
- [ ] Everything looks ok?


### Acknowledging contributors

<!-- Please select the correct box -->

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
