### PR TITLE
fix non-consecutive headings

### DIFF
--- a/book/website/community-handbook/presenting.md
+++ b/book/website/community-handbook/presenting.md
@@ -1,16 +1,16 @@
 # Presenting About _The Turing Way_
 Talks are a great way to engage new communities, teach people about open and reproducible practices, and expand the reach of _The Turing Way_ by introducing the book and inviting new contributors. We encourage any Turing Way contributor to present on behalf of _The Turing Way_, and we ask that you use the guidelines detailed below to shape your talk and ensure consistency with _The Turing Way_ style. 
 
-### Planning a Talk
+## Planning a Talk
 Whether you are submitting an abstract to a conference or you have been invited to speak, a great thing to do is to engage _The Turing Way_ community for support and to publicize the event. Even if the talk is not open to all, you can work with other community members to refine your slides and give a practice talk. If you'd like, please post the details in Slack in the `#community` channel.
 
-### Preparing Slides
+## Preparing Slides
 Please create a GitHub issue using the ["Give a talk" issue template](https://github.com/alan-turing-institute/the-turing-way/issues/new?assignees=&labels=talks-and-workshops%2Cnewsletter&template=give_a_talk.yml&title=%5BTALK%5D+%3Ctitle%3E), which provides links to the resources you will need as well as a checklist for preparing your talk. You will find a range of presentation templates, as well as past presentations, in the [Promotion Pack](https://drive.google.com/drive/folders/1mzGmbJkPnP5q1goQesxDc_E5zAPL0eTF?usp=sharing) folder on Google Drive. Feel free to download the templates and use the slides as a guide for style and content. You can also see past talks on _The Turing Way's_ [community page on Zenodo](https://zenodo.org/communities/the-turing-way/?page=1&size=20).
 
-### Giving a Talk
+## Giving a Talk
 We ask that you include certain acknowledgments in your talk to make sure contributors are credited. You'll find all the info you need in the presentation templates as well as the GitHub issue checklist.
 
-### After Your Talk
+## After Your Talk
 Keep spreading the word! Please archive your slides in two formats: their original (editable) format and as a PDF. If you don't know how to convert PowerPoint or Google slides to PDF, see these [instructions](https://www.wikihow.com/Convert-Powerpoint-to-PDF); following these instructions helps preserve accessibility features for people using screen readers. You can archive your slides on [Zenodo](https://zenodo.org/communities/the-turing-way/), and don't forget to tag "the-turing-way" under Communities.
 
 Please make sure that you credit all of the contributors and presenters of your presentation as authors in the Zenodo upload form. If possible, link to any previous talks where you have used additional slides outside of the provided _The Turing Way_ presentation templates - this can be done in the description part of the upload form.


### PR DESCRIPTION
### Summary

During book build we receive the error:
`WARNING: Non-consecutive header level increase; 1 to 3 [myst.header]`

#2611 

### List of changes proposed in this PR (pull-request)

Here I have modified the level 3 headings to be level 2 headings

### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [ ] Everything looks ok?


### Acknowledging contributors

<!-- Please select the correct box -->

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
