### PR TITLE
Adding infrastructure maintainers to Ways of Working

### DIFF
--- a/ways_of_working.md
+++ b/ways_of_working.md
@@ -33,6 +33,7 @@ It further outlines expectations and responsibilities with regard to working on 
 | Andrea Sánchez-Tapia <br>([AndreaSanchezTapia](https://github.com/AndreaSanchezTapia)) | Independent researcher | The Turing Way Translation and Localisation Co-Lead | 2021 - Present | - |
 |  Danny Garside <br>([@da5nsy](https://github.com/da5nsy)) | Postdoctoral Visiting Fellow, National Institutes of Health (NIH) | The Turing Way Infrastructure Maintainers Co-lead | 2021 - Present | - |
 |  Jim Madge <br>([@JimMadge](https://github.com/JimMadge)) | Senior Research Software Engineer, The Alan Turing Institute | The Turing Way Infrastructure Maintainers Co-lead | 2022 - Present | - |
+|  Brigitta Sipöcz <br>([@bsipocz](https://github.com/bsipocz)) | Research Scientist, Caltech/IPAC | The Turing Way Infrastructure Maintainers Co-lead | 2022 - Present | - |
 
 ## Previous Project Members
 

--- a/ways_of_working.md
+++ b/ways_of_working.md
@@ -31,7 +31,7 @@ It further outlines expectations and responsibilities with regard to working on 
 |  Batool Almarzouq <br>([BatoolMM](https://github.com/BatoolMM)) | Postdoctoral Researcher, KAIMRC and Honorary Research Fellow, The University of Liverpool  | The Turing Way Translation and Localisation Co-Lead | 2020 - Present | - |
 | Alejandro Coca Castro <br>([acocac](https://github.com/acocac)) | Postdoctoral Research Associate, The Alan Turing Institute | The Turing Way Translation and Localisation Co-Lead | 2021 - Present | - |
 | Andrea Sánchez-Tapia <br>([AndreaSanchezTapia](https://github.com/AndreaSanchezTapia)) | Independent researcher | The Turing Way Translation and Localisation Co-Lead | 2021 - Present | - |
-|  Danny Garside <br>([@da5nsy](https://github.com/da5nsy)) | Postdoctoral Visiting Fellow, National Institutes of Health (NIH) | The Turing Way Infrastructure Maintainers Co-lead | 2022 - Present | - |
+|  Danny Garside <br>([@da5nsy](https://github.com/da5nsy)) | Postdoctoral Visiting Fellow, National Institutes of Health (NIH) | The Turing Way Infrastructure Maintainers Co-lead | 2021 - Present | - |
 |  Jim Madge <br>([@JimMadge](https://github.com/JimMadge)) | Senior Research Software Engineer, The Alan Turing Institute | The Turing Way Infrastructure Maintainers Co-lead | 2022 - Present | - |
 
 ## Previous Project Members

--- a/ways_of_working.md
+++ b/ways_of_working.md
@@ -33,7 +33,7 @@ It further outlines expectations and responsibilities with regard to working on 
 | Andrea Sánchez-Tapia <br>([AndreaSanchezTapia](https://github.com/AndreaSanchezTapia)) | Independent researcher | The Turing Way Translation and Localisation Co-Lead | 2021 - Present | - |
 |  Danny Garside <br>([@da5nsy](https://github.com/da5nsy)) | Postdoctoral Visiting Fellow, National Institutes of Health (NIH) | The Turing Way Infrastructure Maintainers Co-lead | 2021 - Present | - |
 |  Jim Madge <br>([@JimMadge](https://github.com/JimMadge)) | Senior Research Software Engineer, The Alan Turing Institute | The Turing Way Infrastructure Maintainers Co-lead | 2022 - Present | - |
-|  Brigitta Sipöcz <br>([@bsipocz](https://github.com/bsipocz)) | Research Scientist, Caltech/IPAC | The Turing Way Infrastructure Maintainers Co-lead | 2022 - Present | - |
+|  Brigitta Sipőcz <br>([@bsipocz](https://github.com/bsipocz)) | Research Software Engineer, Caltech/IPAC -- NASA/IPAC Infrared Science Archive | The Turing Way Infrastructure Maintainers Co-lead | 2022 - Present | - |
 
 ## Previous Project Members
 

--- a/ways_of_working.md
+++ b/ways_of_working.md
@@ -24,13 +24,15 @@ It further outlines expectations and responsibilities with regard to working on 
 | Carlos Martinez-Ortiz <br>([@c-martinez](https://github.com/c-martinez)) | RSE community manager, Netherlands eScience Center | in-kind contribution | Feb 2020 - Present | - |
 | Esther Plomp <br>([@EstherPlomp](https://github.com/EstherPlomp)) | Data Steward, Faculty of Applied Sciences at Delft University of Technology | in-kind contribution | Feb 2020 - Present | - |
 | Lena Karvovskaya <br>([@LenaKarvovskaya](https://github.com/Karvovskaya)) | Community manager RDM and Open Science, VU Amsterdan Library | in-kind contribution | 2021 - Present | - |
-| Sarah Gibson <br>([@sgibson91](https://github.com/sgibson91)) | Open Source Infrastructure Engineer, 2i2c & JupyterHub Community Development | in-kind contribution | - | Prevously: Research Data Scientist, Nov 2018 - Aug 2021 (40%) |
+| Sarah Gibson <br>([@sgibson91](https://github.com/sgibson91)) | Open Source Infrastructure Engineer, 2i2c & JupyterHub Community Development | in-kind contribution, The Turing Way Infrastructure Maintainers Co-lead | 2019 - Present | Prevously: Research Data Scientist, Nov 2018 - Aug 2021 (40%) |
 | Callum Mole <br>([callummole](https://github.com/callummole)) | Research Data Scientist, The Alan Turing Institute | Turing Binder Federation Membership - Project Contact | 2021 - Present | - |
 | Luke Hare <br>([lukehare](https://github.com/lukehare)) | Research Data Scientist, The Alan Turing Institute | Turing Binder Administrator | 2021 - Present | - |
 | Camila Rangel-Smith <br>([crangelsmith](https://github.com/crangelsmith)) | Senior Research Data Scientist, The Alan Turing Institute | The Turing Way Translation and Localisation Co-Lead | 2020 - Present | - |
 |  Batool Almarzouq <br>([BatoolMM](https://github.com/BatoolMM)) | Postdoctoral Researcher, KAIMRC and Honorary Research Fellow, The University of Liverpool  | The Turing Way Translation and Localisation Co-Lead | 2020 - Present | - |
 | Alejandro Coca Castro <br>([acocac](https://github.com/acocac)) | Postdoctoral Research Associate, The Alan Turing Institute | The Turing Way Translation and Localisation Co-Lead | 2021 - Present | - |
 | Andrea Sánchez-Tapia <br>([AndreaSanchezTapia](https://github.com/AndreaSanchezTapia)) | Independent researcher | The Turing Way Translation and Localisation Co-Lead | 2021 - Present | - |
+|  Danny Garside <br>([@da5nsy](https://github.com/da5nsy)) | Postdoctoral Visiting Fellow, National Institutes of Health (NIH) | The Turing Way Infrastructure Maintainers Co-lead | 2022 - Present | - |
+|  Jim Madge <br>([@JimMadge](https://github.com/JimMadge)) | Senior Research Software Engineer, The Alan Turing Institute | The Turing Way Infrastructure Maintainers Co-lead | 2022 - Present | - |
 
 ## Previous Project Members
 
@@ -61,7 +63,7 @@ All The Turing Way project members commit to
 - recording any new updates, exceptions or useful knowledge in project management and core documents needed to facilitate collaboration
 - dedicating their time and expertise in fixing open issues either directly via GitHub or providing mentorship and support to community members and project contributors
 - feedback on issues in open source software used throughout _The Turing Way_ by opening an issue _The Turing Way_ GitHub repo or other open source projects where this issue can be fixed
-- documenting and sharing any conversation from closed spaces (such as email, Slack or 1:1 meeting) in a GitHub issue that could be useful for the community or community members in enabling their work in _The Turing Way_ 
+- documenting and sharing any conversation from closed spaces (such as email, Slack or 1:1 meeting) in a GitHub issue that could be useful for the community or community members in enabling their work in _The Turing Way_
 
 ## Communication
 
@@ -69,7 +71,7 @@ You can reach out to all members by tagging them on GitHub issues or Pull Reques
 
 You can reach the lead investigators of the project through their preferred way of communication:
 You can mention Malvika Sharan (@malvikasharan) and Kirstie Whitaker (@KirstieJane) on a Github issue or pull request, or tag in Slack.
-In addition, you can reach _The Turing Way_ by email (managed by the community manager): theturingway@gmail.com. 
+In addition, you can reach _The Turing Way_ by email (managed by the community manager): theturingway@gmail.com.
 You can also contact Malvika by emailing [msharan@turing.ac.uk](mailto:msharan@turing.ac.uk).
 
 Please join the project members and the wider Turing Way community at our twice-monthly [Collaboration Cafes](https://the-turing-way.netlify.app/community-handbook/coworking/coworking-collabcafe.html), which are great places to discuss ideas for new contributions and to get started with making them. :rocket:
@@ -88,6 +90,6 @@ Project members will:
 - whenever possible, post about the issues and Pull Requests in public forums (newsletter, Slack, Twitter) to facilitate participation from new members in the community.
 - review or assign a reviewer to open Pull Requests for review. This should be taken as an opportunity to connect contributors with specific interests, availability or technical skills that could be useful for the ongoing work.
 - connect issues and Pull Requests where possible (for example, by mentioning 'Fixes #[issue number]' in the Pull Request description). By adding "closes #issue" or [something similar](https://help.github.com/articles/closing-issues-using-keywords/) in a comment on a pull request, merging the pull request will close the issue automatically.
-- once completed, approve Pull Requests (for the contributors to merge them) and/or close issues immediately (if not linked to specific Pull Request) with a comment describing how it was addressed. 
+- once completed, approve Pull Requests (for the contributors to merge them) and/or close issues immediately (if not linked to specific Pull Request) with a comment describing how it was addressed.
 - when reviewing a pull request or commenting on issues, be specific, describe your ideas clearly, comment to request changes or make a pull request to the file that should be merged (please do not use the "request changes" option when reviewing Pull Requests).
 - use your interactions on GitHub or other community spaces to provide support, mentorship and acknowledgement to our community of contributors.


### PR DESCRIPTION
### Summary

Partially addresses #2851 

### List of changes proposed in this PR (pull-request)

In order to codify infrastructure maintenance and ongoing roles within the project, this Ways of Working document is being updated to add @sgibson91, @da5nsy, @JimMadge, @bsipocz as infrastructure maintenance co-leads. 

This format mimicks the title & system used by the Localisation and Translation team (which has self-identified within their team as co-leads). Is this something that this group of people would like to use as well? Is there another format or title that you would like to use?

### What should a reviewer concentrate their feedback on?
- [ ] Are you okay with being named in this document? Are there people missing from this list? 
- [ ] Is yes, is your information correct? Is there more information that should be added?

### Acknowledging contributors

<!-- Please select the correct box -->

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
