### PR TITLE
[do not merge] more debugging of #2897

### DIFF
--- a/book/website/_toc.yml
+++ b/book/website/_toc.yml
@@ -85,7 +85,7 @@ parts:
               - title: Machine Learning Model Licenses
                 file: reproducible-research/licensing/licensing-ml
                 sections:
-                  - title: "Case Studies: Choosing an ML License"
+                  - title: "Case Studies Choosing an ML License for fun"
                     file: reproducible-research/licensing/licensing-ml-case-studies
               - title: License Compatibililty
                 file: reproducible-research/licensing/licensing-compatibility


### PR DESCRIPTION
Remove a colon from an alt title entry

Expected behaviour is that the colon will be removed in the sidebar

related #2897 