### PR TITLE
Remove extra h1 to fix #2897

### DIFF
--- a/book/website/collaboration/research-infrastructure-roles/data-wrangler.md
+++ b/book/website/collaboration/research-infrastructure-roles/data-wrangler.md
@@ -78,7 +78,7 @@ Here are some examples of places that employ Data Wranglers in the UK:
 _Please get in touch if you know of other organisations that you would like to add to this list. This list, and this Data Wrangler page in general, is focused around Data Wrangler roles within an  academic research context, but they will also exist within an industry context._
 
 (cl-infrastructure-data-wranglers-summary)=
-# Data Wranglers: Summary
+## Data Wranglers: Summary
 
 A Data Wrangler position is becoming recognised as a crucial part of any project that involves large amounts of complex data, specifically in a research context.
 They will have a diverse set of technical and interpersonal skills.


### PR DESCRIPTION
### Summary

Fixes #2897

I'm not sure if this is documented in jupyter-book, or a bug, but it looks like the reason that the title override wasn't being respected was that there were two level 1 headers in that file.


### Acknowledging contributors

<!-- Please select the correct box -->

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
