### PR TITLE
Update the website footer to remove copyright assertion, and replace it with a link to the project licenses

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -8,6 +8,8 @@ Software are made available under an MIT license.
 The  license text listed below (describing both CC-BY and MIT licenses as well as their usage in The Turing Way) is re-used under a CC-BY license from The Carpentries community materials.
 (Specifically from the [Reproducible Science Curriculum](https://github.com/Reproducible-Science-Curriculum/sharing-RR-Jupyter/blob/gh-pages/LICENSE.md)).
 
+You can read more about licenses [in the book itself](https://the-turing-way.netlify.app/reproducible-research/licensing.html).
+
 ## Process documents and data
 
 All documentation and chapter materials in this repository are made available under the [Creative Commons Attribution license][cc-by-human].

--- a/book/website/LICENSE.md
+++ b/book/website/LICENSE.md
@@ -2,4 +2,4 @@
 
 All content in this book (located in the `book/website/` folder)
 is licensed under the [Creative Commons Attribution 4.0 International (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/) license.
-For more details please see our [README.md](../../README.md) file.
+For more details please see our [project-wide LICENSE.md file](../../LICENSE.md).

--- a/book/website/_config.yml
+++ b/book/website/_config.yml
@@ -7,7 +7,7 @@
 # Book settings
 title                       : The Turing Way  # The title of the book. Will be placed in the left navbar.
 author                      : The Turing Way Community  # The author of the book
-copyright                   : "2023"  # Copyright year to be placed in the footer
+copyright                   : "2019-2023"  # Copyright year to be placed in the footer
 logo                        : "./figures/logo-detail-with-text.svg"  # A path to the book logo
 email                       : "theturingway@gmail.com"
 exclude_patterns            : ["LICENSE.md"]  # Patterns to skip when building the book. Can be glob-style (for example "*skip.ipynb")

--- a/book/website/_config.yml
+++ b/book/website/_config.yml
@@ -7,7 +7,7 @@
 # Book settings
 title                       : The Turing Way  # The title of the book. Will be placed in the left navbar.
 author                      : The Turing Way Community  # The author of the book
-copyright                   : "2020-2021"  # Copyright year to be placed in the footer
+copyright                   : "2023"  # Copyright year to be placed in the footer
 logo                        : "./figures/logo-detail-with-text.svg"  # A path to the book logo
 email                       : "theturingway@gmail.com"
 exclude_patterns            : ["LICENSE.md"]  # Patterns to skip when building the book. Can be glob-style (for example "*skip.ipynb")
@@ -32,8 +32,10 @@ html:
   baseurl                   : "https://the-turing-way.netlify.com"  # The base URL where your book will be hosted. Used for creating image previews and social links. for example: https://mypage.com/mybook/
   extra_navbar              : Visit our <a href="https://github.com/alan-turing-institute/the-turing-way">GitHub Repository</a>
     <div>This book is powered by <a href="https://jupyterbook.org">Jupyter Book</a></div>
+  extra_footer: |
+    The Turing Way Community makes all of their materials publicly available under  <a href="https://github.com/alan-turing-institute/the-turing-way/blob/main/LICENSE.md">open source licenses</a>
   comments:
-    hypothesis: true
+    hypothesis              : true
 
 #######################################################################################
 # Launch button settings
@@ -54,6 +56,7 @@ sphinx:
   extra_extensions          :  # A list of extra extensions to load by Sphinx.
   config                    :  # key-value pairs to directly over-ride the Sphinx configuration
     language                : en
+    html_show_copyright     : false
 
 bibtex_bibfiles:
     - _bibliography/references.bib


### PR DESCRIPTION
### Summary

- Update the website footer to remove copyright assertion, and replace it with a link to the project licenses.
- Minor tweaks updating links as I went

Resolves #2772 

Followed these instructions: https://jupyterbook.org/en/stable/advanced/html.html?#adding-a-license-to-your-html-footer

### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [ ] Everything looks ok?


### Acknowledging contributors

<!-- Please select the correct box -->

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
