### PR TITLE
Fixed dead link to eScience Center language guides

### DIFF
--- a/book/website/reproducible-research/code-quality/code-quality-style.md
+++ b/book/website/reproducible-research/code-quality/code-quality-style.md
@@ -10,7 +10,7 @@ Therefore, adhering to a coding style reduces the risk of mistakes and makes it 
 
 For example, [PEP8](https://www.python.org/dev/peps/pep-0008/) is the most widely used Python coding style and [ECMAScript 6](http://es6-features.org/) aka [ES6](http://es6-features.org/) is the scripting-language specification standardized by ECMA International for programming in Javascript.
 
-For commonly used style guides for various programming languages see the [Language Guides](https://guide.esciencecenter.nl/best_practices/language_guides/languages_overview.html).
+For commonly used style guides for various programming languages see the [Language Guides](https://guide.esciencecenter.nl/#/best_practices/language_guides/languages_overview).
 Google also has a [style guide](https://code.google.com/p/google-styleguide/) for many languages that are used in open source projects originating out of Google.
 
 (rr-code-style-and-formatting)=


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent. For example: "Fixes #58", or "Addresses (but does not close) #238". -->

Fixes a dead link to the eScience Center language guides.
* Old (dead) link: https://guide.esciencecenter.nl/best_practices/language_guides/languages_overview.html
* New (working) link: https://guide.esciencecenter.nl/#/best_practices/language_guides/languages_overview

### List of changes proposed in this PR (pull-request)
* Dead link fix

### What should a reviewer concentrate their feedback on?
* Check if the new link points to the right page

### Acknowledging contributors

<!-- Please select the correct box -->

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file.
- [x] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file: GitHubID = 8987504, Profile = https://github.com/tpronk
