### PR TITLE
Fix reference shortcut text

### DIFF
--- a/book/website/_bibliography/references.bib
+++ b/book/website/_bibliography/references.bib
@@ -1991,7 +1991,7 @@ DOI = {10.3390/publications8020021}
 @misc{datastudygrouproche2020,
 	doi = {http://doi.org/10.5281/zenodo.3876989},
 	year = {2020},
-	author = {Data Study Group Team},
+	author = "{Data Study Group Team}",
 	title = {Data Study Group Final Report - Roche},
 	url = {https://www.turing.ac.uk/news/publications/data-study-group-final-report-roche}
 

--- a/book/website/_bibliography/references.bib
+++ b/book/website/_bibliography/references.bib
@@ -1988,7 +1988,7 @@ DOI = {10.3390/publications8020021}
   journal = {PLOS Computational Biology}
 }
 
-@misc{datastudygrouproche,
+@misc{datastudygrouproche2020,
 	doi = {http://doi.org/10.5281/zenodo.3876989},
 	year = {2020},
 	author = {Data Study Group Team},


### PR DESCRIPTION
Reference in the establishing academia-industry collaboration had the wrong shortcut for the bibtex reference

<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent. For example: "Fixes #58", or "Addresses (but does not close) #238". -->

No open issue

Small fix so reference to data study group formats correctly

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* Rename bibtex entry so the book text find the right reference

### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [ ] Does the link to the Turing-Roche Data Study Group in on the `collaboration/academic-industry/academic-industry-establish` page format correctly
- [ ] Everything looks ok?

### Acknowledging contributors

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file.
