### PR TITLE
Fix link to Continuous Integration chapter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -303,7 +303,7 @@ What happens if the continuous integration (CI) fails (for example, if the pull 
 The CI could fail for a number of reasons.
 At the bottom of the pull request, where it says whether your build passed or failed, you can click “Details” next to the test, which takes you to a CI run log site.
 If you have the write access to the repo, you can view the log or rerun the checks by clicking the “Restart build” button in the top right.
-You can learn more about CI in the {ref}`Continuous Integration chapter<rr-ci>`!
+You can learn more about CI in the [Continuous Integration chapter](https://the-turing-way.netlify.app/reproducible-research/ci.html)!
 
 GitHub has a [nice introduction][github-flow] to the pull request workflow, but please [get in touch](#get-in-touch) if you have any questions :balloon:.
 


### PR DESCRIPTION
### Summary

While reading the contribution guidelines in `CONTRIBUTING.md`, I noticed a broken link.

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* Fix link to "Continuous Integration chapter"

### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [ ] Did I use the correct way to specify the link in this markdown file? I went by example from other instances in the file.
- [ ] Everything looks ok?

### Acknowledging contributors

_Whether anything needs to get done here depends on if #3174 (my first contribution) is merged before this._

- [ ] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file: 

https://github.com/spier
