### PR TITLE
Latin abbrevs: better image caption and link

### DIFF
--- a/book/website/community-handbook/style.md
+++ b/book/website/community-handbook/style.md
@@ -43,7 +43,7 @@ Note, that the formatting will be retained, so we can split each sentence to a n
 ## Avoid Latin Abbreviation
 
 Please do not use Latin abbreviations.
-See the [Gov.uk recommendations](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style) for details.
+See the [Gov.uk recommendations](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#eg-etc-and-ie) for details.
 
 Some of these abbreviations are:
 
@@ -55,6 +55,7 @@ alt: an image with a list of 3 latin abbreviations
 ---
 A list of latin abbreviations for *exempli gratia* (for example), *et-cetera* (so on), and *id est* (that is).
 Screenshot of part of the [list of Common Latin Abbreviations for APA Style](https://blog.apastyle.org/files/apa-latin-abbreviations-table-2.pdf).
+We use a screenshot instead of plain text to comply with continuous integration tests (see below).
 ```
 
 Instead of the first abbreviation in the table for *exempli gratia*, which can sometimes read aloud as ‘egg’ by screen reading software, please use ‘for example’ or ‘such as’ or ‘like’ or ‘including’ - whichever works best in the specific context.


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

This commit improves the Style guidelines about Latin abbreviations.

### List of changes proposed in this PR (pull-request)

The image caption is updated to clarify that a screenshot is used to avoid triggering CI failures (at the point where the image is first encountered, instead of later in the text).

Also, the hyperlink to the Gov.UK style guide is updated to point to the specific section on Latin abbreviations instead of the style guide as a whole.

### What should a reviewer concentrate their feedback on?

- [ ] Everything looks ok?


### Acknowledging contributors

<!-- Please select the correct box -->

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file.
- [x] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file: @srtee
