### PR TITLE
Fix link on Record of Contributions, and also add a header note signalling towards the infrastructure documentation for that page

### DIFF
--- a/book/website/afterword/contributors-record.md
+++ b/book/website/afterword/contributors-record.md
@@ -1,4 +1,10 @@
 (contributors-record)=
+# Record of Contributions
+
+```{note}
+This page is formed from a combination of the [`contributors.md`](https://github.com/alan-turing-institute/the-turing-way/blob/main/contributors.md) file and the contributors table in the [`README file`](https://github.com/alan-turing-institute/the-turing-way#contributors). Pulling these files together into this page requires a little infrastructure wizardry under the hood, which you can read about in the section on {ref}`ch-infrastructure-contributors`.
+```
+
 ```{include} ../../../contributors.md
 ```
 

--- a/book/website/community-handbook/infrastructure/infrastructure-contributors.md
+++ b/book/website/community-handbook/infrastructure/infrastructure-contributors.md
@@ -1,3 +1,4 @@
+(ch-infrastructure-contributors)=
 # Publishing Contributors
 
 Keeping track of contributions of all types is important: both code and non-code contributors.

--- a/book/website/community-handbook/infrastructure/infrastructure-contributors.md
+++ b/book/website/community-handbook/infrastructure/infrastructure-contributors.md
@@ -11,7 +11,7 @@ This page documents how these sources are combined to create the {ref}`Record of
 ## Personal Highlights
 
 The {ref}`Personal Highlight section<contributors-record-highlights>` is taken directly from [`contributors.md`](https://github.com/alan-turing-institute/the-turing-way/blob/main/contributors.md) in the root of the repository.
-This is inserted into [`contributors-record.md`](https://github.com/alan-turing-institute/the-turing-way/blob/main/book/website/afterword/contributors-record.md`) verbatim using the [`include` docutils directive](https://docutils.sourceforge.io/docs/ref/rst/directives.html#including-an-external-document-fragment).
+This is inserted into [`contributors-record.md`](https://github.com/alan-turing-institute/the-turing-way/blob/main/book/website/afterword/contributors-record.md) verbatim using the [`include` docutils directive](https://docutils.sourceforge.io/docs/ref/rst/directives.html#including-an-external-document-fragment).
 
 To modify this section you would change `contributors.md` and rebuild the book.
 

--- a/contributors.md
+++ b/contributors.md
@@ -6,7 +6,7 @@ Contributions to _The Turing Way_ may include but are not limited to, bug fixing
 We recognise all these contributions and acknowledge our community members fairly.
 For example, using [all contributors bot](https://allcontributors.org) we update the contributors table with each person's name, where the emoji keys indicate the different tasks they have done (see the [README file](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors)).
 We understand that different contributions mean different things to people and may translate differently towards their personal interest, skill development, value exchange and advancement of their careers.
-Therefore, we also offer the [contributors.md](https://github.com/alan-turing-institute/the-turing-way/contributors.md) file as a dedicated location to capture personal highlights from _The Turing Way_ community members.
+Therefore, we also offer the [contributors.md](https://github.com/alan-turing-institute/the-turing-way/blob/main/contributors.md) file as a dedicated location to capture personal highlights from _The Turing Way_ community members.
 
 Individual contributors are welcome to provide their details under the section "Personal Highlights from _The Turing Way_ Contributors".
 Organisational support and collaborations are listed in the section, "Collaborating Organisations".

--- a/contributors.md
+++ b/contributors.md
@@ -1,7 +1,3 @@
-# Record of Contributions
-
-*The `contributors.md` file and the contributors table in the `README file` together form the record of contributions in _The Turing Way_.*
-
 Contributions to _The Turing Way_ may include but are not limited to, bug fixing, chapter planning, writing, editing, reviewing, idea generation, presentation, project management, and maintenance.
 We recognise all these contributions and acknowledge our community members fairly.
 For example, using [all contributors bot](https://allcontributors.org) we update the contributors table with each person's name, where the emoji keys indicate the different tasks they have done (see the [README file](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors)).


### PR DESCRIPTION
Toward #3219 